### PR TITLE
Reduce vault-manager cpu and memory limits / requests

### DIFF
--- a/openshift/vault-manager.template.yaml
+++ b/openshift/vault-manager.template.yaml
@@ -84,13 +84,13 @@ parameters:
   displayName: vault-manager version
   description: vault-manager version which defaults to latest
 - name: MEMORY_REQUESTS
-  value: 200Mi
+  value: 25Mi
 - name: MEMORY_LIMIT
-  value: 500Mi
+  value: 100Mi
 - name: CPU_REQUESTS
-  value: 250m
+  value: 25m
 - name: CPU_LIMIT
-  value: 500m
+  value: 100m
 - name: REPLICAS
   value: '1'
 - name: RECONCILE_SLEEP_TIME


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12532803/134744443-193cf41d-7d67-49c6-af4f-cb7d079a80be.png)


*CPU*

```
File: vault-manager
Type: cpu
Time: Sep 24, 2021 at 2:35pm (PDT)
Duration: 9.79s, Total samples = 610ms ( 6.23%)
Showing nodes accounting for 610ms, 100% of 610ms total
      flat  flat%   sum%        cum   cum%
      80ms 13.11% 13.11%       80ms 13.11%  runtime.epollwait
      60ms  9.84% 22.95%       60ms  9.84%  runtime.futex
      30ms  4.92% 27.87%       30ms  4.92%  runtime.findfunc
      30ms  4.92% 32.79%       40ms  6.56%  syscall.Syscall
      20ms  3.28% 36.07%       20ms  3.28%  runtime.madvise
      20ms  3.28% 39.34%       20ms  3.28%  runtime.memclrNoHeapPointers
      10ms  1.64% 40.98%       10ms  1.64%  aeshashbody
      10ms  1.64% 42.62%       20ms  3.28%  crypto/x509.parseCertificate
      10ms  1.64% 44.26%       10ms  1.64%  encoding/base64.(*Encoding).Decode
      10ms  1.64% 45.90%       10ms  1.64%  fmt.(*pp).doPrintf
      10ms  1.64% 47.54%       30ms  4.92%  github.com/hashicorp/vault/api.DefaultConfig
      10ms  1.64% 49.18%       20ms  3.28%  github.com/hashicorp/vault/sdk/helper/jsonutil.DecodeJSONFromReader
      10ms  1.64% 50.82%       10ms  1.64%  github.com/mitchellh/mapstructure.(*Decoder).decodeString
      10ms  1.64% 52.46%       30ms  4.92%  golang.org/x/net/http2.(*clientConnReadLoop).handleResponse
      10ms  1.64% 54.10%       10ms  1.64%  math/big.basicSqr
      10ms  1.64% 55.74%       10ms  1.64%  memeqbody
      10ms  1.64% 57.38%       10ms  1.64%  net.isDomainName
      10ms  1.64% 59.02%       10ms  1.64%  net/http.Header.Clone
      10ms  1.64% 60.66%       10ms  1.64%  runtime.(*guintptr).cas (inline)
      10ms  1.64% 62.30%       30ms  4.92%  runtime.(*pageAlloc).scavengeRangeLocked
      10ms  1.64% 63.93%       10ms  1.64%  runtime.(*randomEnum).done (inline)
      10ms  1.64% 65.57%       10ms  1.64%  runtime.(*randomEnum).next (inline)
      10ms  1.64% 67.21%       10ms  1.64%  runtime.(*spanSet).pop
      10ms  1.64% 68.85%       10ms  1.64%  runtime.(*sweepLocked).sweep
      10ms  1.64% 70.49%       10ms  1.64%  runtime.(*sweepLocker).tryAcquire (inline)
      10ms  1.64% 72.13%       10ms  1.64%  runtime.checkRunqsNoP
      10ms  1.64% 73.77%       10ms  1.64%  runtime.checkTimers
      10ms  1.64% 75.41%       10ms  1.64%  runtime.gopark
      10ms  1.64% 77.05%       50ms  8.20%  runtime.mallocgc
      10ms  1.64% 78.69%       10ms  1.64%  runtime.mapaccess1
      10ms  1.64% 80.33%       20ms  3.28%  runtime.mapassign_faststr
      10ms  1.64% 81.97%       10ms  1.64%  runtime.pMask.read (inline)
      10ms  1.64% 83.61%       10ms  1.64%  runtime.runqgrab
      10ms  1.64% 85.25%       10ms  1.64%  runtime.scanblock
      10ms  1.64% 86.89%       10ms  1.64%  runtime.scanobject
      10ms  1.64% 88.52%       10ms  1.64%  runtime.selectgo
      10ms  1.64% 90.16%       10ms  1.64%  runtime.stackcache_clear
      10ms  1.64% 91.80%       60ms  9.84%  runtime.stealWork
      10ms  1.64% 93.44%       10ms  1.64%  runtime.wirep
      10ms  1.64% 95.08%       10ms  1.64%  runtime.write1
      10ms  1.64% 96.72%       10ms  1.64%  syscall.Connect
      10ms  1.64% 98.36%       10ms  1.64%  syscall.RawSyscall
      10ms  1.64%   100%       10ms  1.64%  time.Now
```

*MEM*

```
File: vault-manager
Type: inuse_space
Time: Sep 24, 2021 at 2:35pm (PDT)
Showing nodes accounting for 811.63kB, 93.44% of 868.57kB total
Dropped 60 nodes (cum <= 4.34kB)
      flat  flat%   sum%        cum   cum%
  120.99kB 13.93% 13.93%   192.30kB 22.14%  encoding/json.(*decodeState).objectInterface
  105.98kB 12.20% 26.13%   105.98kB 12.20%  encoding/pem.Decode
   84.19kB  9.69% 35.82%    84.19kB  9.69%  bytes.makeSlice
   67.31kB  7.75% 43.57%    67.31kB  7.75%  encoding/json.unquote (inline)
   49.47kB  5.70% 49.27%    49.47kB  5.70%  crypto/x509.(*CertPool).addCertFunc (inline)
   38.34kB  4.41% 53.68%    38.34kB  4.41%  regexp.(*bitState).reset
   37.28kB  4.29% 57.97%    37.28kB  4.29%  reflect.mapassign
   28.39kB  3.27% 61.24%   183.84kB 21.17%  crypto/x509.(*CertPool).AppendCertsFromPEM
   25.24kB  2.91% 64.15%    25.24kB  2.91%  runtime.malg
   18.08kB  2.08% 66.23%    18.08kB  2.08%  runtime.allocm
   18.08kB  2.08% 68.31%    18.08kB  2.08%  sync.(*Pool).pinSlow
   17.92kB  2.06% 70.38%    26.22kB  3.02%  crypto/x509.parseCertificate
   16.50kB  1.90% 72.28%    16.50kB  1.90%  vendor/golang.org/x/net/dns/dnsmessage.(*Name).pack
   16.30kB  1.88% 74.15%    16.30kB  1.88%  golang.org/x/net/http2.(*ClientConn).frameScratchBuffer
   16.30kB  1.88% 76.03%    16.30kB  1.88%  net/http.(*http2ClientConn).frameScratchBuffer
   16.30kB  1.88% 77.90%    16.30kB  1.88%  net/http.(*http2Transport).newClientConn.func1
   14.44kB  1.66% 79.57%    14.44kB  1.66%  golang.org/x/net/http2.(*Transport).newClientConn.func1
   10.27kB  1.18% 80.75%    28.33kB  3.26%  github.com/hashicorp/go-retryablehttp.(*Client).Do
   10.16kB  1.17% 81.92%   210.49kB 24.23%  encoding/json.(*decodeState).arrayInterface
    8.38kB  0.96% 82.88%    20.61kB  2.37%  github.com/hashicorp/vault/api.DefaultConfig
    8.20kB  0.94% 83.83%     8.20kB  0.94%  sync.(*Map).dirtyLocked
    8.09kB  0.93% 84.76%     8.09kB  0.93%  net/http.setRequestCancel.func4
    8.02kB  0.92% 85.68%    55.28kB  6.36%  encoding/json.(*decodeState).literalInterface
    6.83kB  0.79% 86.47%    13.67kB  1.57%  crypto/tls.(*Conn).readHandshake
    6.33kB  0.73% 87.20%     6.33kB  0.73%  bufio.NewReaderSize (inline)
    6.33kB  0.73% 87.93%     6.33kB  0.73%  bufio.NewWriterSize (inline)
    5.45kB  0.63% 88.55%     5.45kB  0.63%  golang.org/x/net/http2/hpack.(*headerFieldTable).addEntry (inline)
    5.45kB  0.63% 89.18%     5.45kB  0.63%  reflect.unsafe_NewArray
    4.73kB  0.54% 89.73%     4.73kB  0.54%  net/http.(*http2Framer).WriteDataPadded
    4.09kB  0.47% 90.20%     8.61kB  0.99%  regexp.newBitState (inline)
    4.06kB  0.47% 90.66%     8.11kB  0.93%  net.(*Dialer).DialContext
    4.05kB  0.47% 91.13%    18.07kB  2.08%  golang.org/x/net/http2.(*ClientConn).roundTrip
    4.04kB  0.47% 91.60%    76.03kB  8.75%  github.com/app-sre/vault-manager/toplevel/auth.config.Apply
    4.02kB  0.46% 92.06%     8.17kB  0.94%  golang.org/x/net/http2.configureTransport
    4.02kB  0.46% 92.52%     8.02kB  0.92%  encoding/json.cachedTypeFields
    4.01kB  0.46% 92.98%   200.32kB 23.06%  encoding/json.(*decodeState).valueInterface
    4.01kB  0.46% 93.44%    50.95kB  5.87%  gopkg.in/yaml%2ev2.resolv
```
