### PR TITLE
Refactor approle-related entity check/fix "unauthorized" bug

### DIFF
--- a/pkg/vault/client.go
+++ b/pkg/vault/client.go
@@ -216,17 +216,6 @@ func GetVaultVersion() string {
 	return info.Version
 }
 
-func ListApproles() map[string]interface{} {
-	existingApproles, err := getClient().Logical().List("auth/approle/role")
-	if err != nil {
-		log.WithError(err).Fatal("[Vault Auth] failed to list Vault approles")
-	}
-	if existingApproles == nil {
-		return nil
-	}
-	return existingApproles.Data
-}
-
 func ListEntities() map[string]interface{} {
 	existingEntities, err := getClient().Logical().List("identity/entity/id")
 	if err != nil {

--- a/toplevel/entity/entity.go
+++ b/toplevel/entity/entity.go
@@ -392,6 +392,13 @@ func getExistingEntitiesDetails(entities []entity, threadPoolSize int) {
 				// check every alias's metadata and see if the name matches an existing approle
 				if rawAlias["metadata"] != nil {
 					metadata := rawAlias["metadata"].(map[string]interface{})
+					// oidc logins w/ out permission also create entities/entity-aliases
+					// unlike approle logins, they do not create 'role_name' metadata
+					// however, they do initalize metadata to `map[]`, instead of the `nil` we assign for explicit entity creations
+					// this check is to handle such existing entities
+					if len(metadata) == 0 {
+						break
+					}
 					if _, exists := approles[metadata["role_name"].(string)]; exists {
 						isApprole = true
 						break


### PR DESCRIPTION
PR addresses a bug that occurs when "unauthorized" (anyone in RH SSO can login to vault but will have no permissions unless associated w/ a vault role.. these people are unauthorized in this context) users log in to Vault. 

When an unauthorized user OR approle logs in, Vault generates an entity and entity alias. This behavior complicates reconciliation for entities because we do not want to remove entities associated with approles but do want to remove the unauthorized entities. The prior logic used metadata populated on entity aliases (`role_name`) associated with approle entities to filter them out from inclusion in reconcile (avoid deletion). However, this caused a bug for unauthorized-related entities because while regular entities contain `nil` for metadata (the value checked to determine approle or not), the unauthorized contained an empty initialized map.

New approach does not need to check metadata and instead pulls mount_type off the aliases to determine type for associated entity.