### PR TITLE
Improve handling of various entity alias types

### DIFF
--- a/cmd/vault-manager/main.go
+++ b/cmd/vault-manager/main.go
@@ -93,6 +93,7 @@ func main() {
 			}
 			err = toplevel.Apply(config.Name, address, dataBytes, dryRun, threadPoolSize)
 			if err != nil {
+				fmt.Println(fmt.Sprintf("Error encountered during reconciliation of %s toplevel", config.Name))
 				fmt.Println(fmt.Sprintf("SKIPPING REMAINING RECONCILIATION FOR %s", address))
 				break
 			}

--- a/cmd/vault-manager/main.go
+++ b/cmd/vault-manager/main.go
@@ -93,7 +93,6 @@ func main() {
 			}
 			err = toplevel.Apply(config.Name, address, dataBytes, dryRun, threadPoolSize)
 			if err != nil {
-				fmt.Println(fmt.Sprintf("Error encountered during reconciliation of %s toplevel", config.Name))
 				fmt.Println(fmt.Sprintf("SKIPPING REMAINING RECONCILIATION FOR %s", address))
 				break
 			}

--- a/toplevel/entity/entity.go
+++ b/toplevel/entity/entity.go
@@ -263,6 +263,9 @@ func (c config) Apply(address string, entriesBytes []byte, dryRun bool, threadPo
 		}
 		err = performAliasReconcile(address, aliasesToBeWritten, aliasesToBeDeleted, aliasesToBeUpdated)
 		if err != nil {
+			log.WithError(err).WithFields(log.Fields{
+				"instance": address,
+			}).Info("[Vault Identity] error occurred during reconciliation of entity aliases")
 			return err
 		}
 	}

--- a/toplevel/entity/entity.go
+++ b/toplevel/entity/entity.go
@@ -205,7 +205,7 @@ func (c config) Apply(address string, entriesBytes []byte, dryRun bool, threadPo
 		return err
 	}
 
-	pruneApproleEntities(&existingEntities)
+	pruneNonOidcEntities(&existingEntities)
 
 	if existingEntities != nil && len(existingEntities) > 0 {
 		err := getExistingEntitiesDetails(address, existingEntities, threadPoolSize)
@@ -361,21 +361,36 @@ func createBaseExistingEntities(instanceAddr string) ([]entity, error) {
 				return nil, errors.New(fmt.Sprintf(
 					"Failed to convert element within `aliases` to map[string]interface{} for entity id: %s", id))
 			}
+
 			if _, exists := vals["id"]; !exists {
 				return nil, errors.New(fmt.Sprintf(
 					"Required `id` attribute not found on alias element for entity id: %s", id))
 			}
 			aliasId := vals["id"].(string)
+
 			if _, exists := vals["name"]; !exists {
 				return nil, errors.New(fmt.Sprintf(
-					"Required `name` attribute not found on alias element for entity-alias id: %s", id))
+					"Required `name` attribute not found on alias element for entity id: %s", id))
 			}
 			aliasName := vals["name"].(string)
+
+			mountType := ""
 			if _, exists := vals["mount_type"]; !exists {
-				return nil, errors.New(fmt.Sprintf(
-					"Required `mount_type` attribute not found on alias element for entity-alias id: %s", id))
+				accessor, exists := vals["mount_accessor"]
+				if !exists {
+					return nil, errors.New(fmt.Sprintf(
+						"Required `mount_accessor` attribute not found on alias element for entity id: %s", id))
+				}
+				// some aliases do not contain mount_type. avoid error for these as irrelevant to current reconcile
+				// ex: userpass entity-aliases
+				if strings.Contains(accessor.(string), "oidc") {
+					return nil, errors.New(fmt.Sprintf(
+						"Required `mount_type` attribute not found on alias element for entity id: %s", id))
+				}
+			} else {
+				mountType = vals["mount_type"].(string)
 			}
-			mountType := vals["mount_type"].(string)
+
 			processedAliases = append(processedAliases, entityAlias{
 				Id:       aliasId,
 				Name:     aliasName,
@@ -470,13 +485,14 @@ func getExistingEntitiesDetails(instanceAddr string, entities []entity, threadPo
 	return nil
 }
 
-// removes existing entities that have been flagged as being connected to approles
+// removes existing entities that have been flagged as being connected to approles, github, etc
 // from inclusion in reconcile process
-func pruneApproleEntities(entities *[]entity) {
+func pruneNonOidcEntities(entities *[]entity) {
 	var isOidc bool
 	i := 0
 	for _, e := range *entities {
 		isOidc = true
+		// ignore entire entity if a single alias is not oidc type
 		for _, a := range e.Aliases {
 			if a.AuthType != "oidc" {
 				isOidc = false


### PR DESCRIPTION
Vault's underlying implementation of various auth methods results in entities/entity aliases that have inconsistent attributes. This PR improves handling of these variations.

This will allow identity-related resource reconciliation to be enabled within commercial

ticket: https://issues.redhat.com/browse/APPSRE-6072