### PR TITLE
Refactor method for retrieving oidc auth client secret

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 # used for testing in /tests/run-tests.sh
 export QONTRACT_SERVER_NAME=qontract-server
 export QONTRACT_SERVER_IMAGE=quay.io/app-sre/qontract-server
-export QONTRACT_SERVER_IMAGE_TAG=64b433b
+export QONTRACT_SERVER_IMAGE_TAG=28ff0df
 
 # used for testing in /tests/run-tests.sh
 export KEYCLOAK_NAME=keycloak

--- a/pkg/vault/client.go
+++ b/pkg/vault/client.go
@@ -203,6 +203,9 @@ func ReadSecret(instanceAddr, secretPath, engineVersion string) map[string]inter
 			"engineVersion": engineVersion,
 		}).Fatal("[Vault Client] failed to read Vault secret")
 	}
+	if raw == nil {
+		return nil
+	}
 	// vault api returns different payload depending on version
 	switch engineVersion {
 	case KV_V1:

--- a/pkg/vault/client.go
+++ b/pkg/vault/client.go
@@ -195,6 +195,8 @@ func WriteSecret(instanceAddr string, secretPath string, secretData map[string]i
 
 // read secret from vault and return the secret map
 func ReadSecret(instanceAddr, secretPath, engineVersion string) map[string]interface{} {
+	// vault manager does not support reverting and should always reference latest data within a-i
+	// therefore, secret version is not specified for KV V2 secrets
 	raw, err := getClient(instanceAddr).Logical().Read(secretPath)
 	if err != nil {
 		log.WithError(err).WithFields(log.Fields{

--- a/pkg/vault/client.go
+++ b/pkg/vault/client.go
@@ -65,7 +65,7 @@ func createClient(a string, b AuthBundle, bwg *utils.BoundedWaitGroup, mutex *sy
 
 	accessCreds := make(map[string]string)
 	for _, cred := range b.VaultSecrets {
-		processedCred, err := processAccessCredential(cred, b.SecretEngine)
+		processedCred, err := ProcessVaultCredential(cred.Path, cred.Field, b.SecretEngine)
 		if err != nil {
 			log.WithError(err).Fatal()
 		}
@@ -104,39 +104,21 @@ func createClient(a string, b AuthBundle, bwg *utils.BoundedWaitGroup, mutex *sy
 }
 
 // attempts to read/proccess a single access credential for a particular vault instance
-func processAccessCredential(cred *VaultSecret, secretEngine string) (string, error) {
-	raw := ReadSecret(masterAddress, cred.Path)
-	if raw == nil {
-		log.Fatalf("[Vault Client] Failed to retrieve secret from master instance at path %s", cred.Path)
+func ProcessVaultCredential(path, field, engineVersion string) (string, error) {
+	secret := ReadSecret(masterAddress, path, engineVersion)
+	if secret == nil {
+		return "", errors.New(
+			fmt.Sprintf("[Vault Client] Failed to retrieve secret from master instance at path %s", path))
 	}
-	// vault api returns different payload depending on version
-	switch secretEngine {
-	case KV_V1:
-		if _, exists := raw.Data[cred.Field]; !exists {
-			return "", errors.New(fmt.Sprintf("[Vault Client] Field `%s` does not exist at path: `%s`", cred.Field, cred.Path))
-		}
-		if _, ok := raw.Data[cred.Field].(string); !ok {
-			return "", errors.New(fmt.Sprintf("[Vault Client] Field `%s` cannot be converted to string", cred.Field))
-		}
-		return raw.Data[cred.Field].(string), nil
-	case KV_V2:
-		mapped, ok := raw.Data["data"].(map[string]interface{})
-		if !ok {
-			return "", errors.New(fmt.Sprintf("[Vault Client] Failed to process raw result at path: `%s`", cred.Path))
-		}
-		if len(mapped) < 1 {
-			return "", errors.New(fmt.Sprintf("[Vault Client] Data does not exist at path: `%s`", cred.Path))
-		}
-		if _, exists := mapped[cred.Field]; !exists {
-			return "", errors.New(fmt.Sprintf("[Vault Client] Field `%s` does not exist at path: `%s`", cred.Field, cred.Path))
-		}
-		if _, ok := mapped[cred.Field].(string); !ok {
-			return "", errors.New(fmt.Sprintf("[Vault Client] Field `%s` cannot be converted to string", cred.Field))
-		}
-		return mapped[cred.Field].(string), nil
-	default:
-		return "", errors.New(fmt.Sprintf("[Vault Client] Unsupported secret engine type %s", secretEngine))
+	if _, exists := secret[field]; !exists {
+		return "", errors.New(
+			fmt.Sprintf("[Vault Client] Field `%s` does not exist at path: `%s`", field, path))
 	}
+	if _, ok := secret[field].(string); !ok {
+		return "", errors.New(
+			fmt.Sprintf("[Vault Client] Field `%s` cannot be converted to string", field))
+	}
+	return secret[field].(string), nil
 }
 
 // configureMaster initializes vault client for the master instance
@@ -184,6 +166,20 @@ func getClient(instanceAddr string) *api.Client {
 	return vaultClients[instanceAddr]
 }
 
+// return proper secret path format based upon kv version
+// kv v2 api inserts /data/ between the root engine name and remaining path
+func FormatSecretPath(secret string, secretEngine string) string {
+	if secretEngine == KV_V2 {
+		sliced := strings.SplitN(secret, "/", 2)
+		if len(sliced) < 2 {
+			log.Fatal("[Vault Instance] Error processessing kv_v2 secret path")
+		}
+		return fmt.Sprintf("%s/data/%s", sliced[0], sliced[1])
+	} else {
+		return secret
+	}
+}
+
 // write secret to vault
 func WriteSecret(instanceAddr string, secretPath string, secretData map[string]interface{}) {
 	if !DataInSecret(instanceAddr, secretData, secretPath) {
@@ -197,16 +193,38 @@ func WriteSecret(instanceAddr string, secretPath string, secretData map[string]i
 	}
 }
 
-// read secret from vault
-func ReadSecret(instanceAddr string, secretPath string) *api.Secret {
-	secret, err := getClient(instanceAddr).Logical().Read(secretPath)
+// read secret from vault and return the secret map
+func ReadSecret(instanceAddr, secretPath, engineVersion string) map[string]interface{} {
+	raw, err := getClient(instanceAddr).Logical().Read(secretPath)
 	if err != nil {
 		log.WithError(err).WithFields(log.Fields{
-			"path":     secretPath,
-			"instance": instanceAddr,
+			"path":          secretPath,
+			"instance":      instanceAddr,
+			"engineVersion": engineVersion,
 		}).Fatal("[Vault Client] failed to read Vault secret")
 	}
-	return secret
+	// vault api returns different payload depending on version
+	switch engineVersion {
+	case KV_V1:
+		return raw.Data
+	case KV_V2:
+		mapped, ok := raw.Data["data"].(map[string]interface{})
+		if !ok {
+			log.WithError(err).WithFields(log.Fields{
+				"path":          secretPath,
+				"instance":      instanceAddr,
+				"engineVersion": engineVersion,
+			}).Fatal("[Vault Client] failed to process `data` from result of read")
+		}
+		return mapped
+	default:
+		log.WithError(err).WithFields(log.Fields{
+			"path":          secretPath,
+			"instance":      instanceAddr,
+			"engineVersion": engineVersion,
+		}).Fatal("[Vault Client] unsupported KV engine version passed to ReadSecret()")
+		return nil
+	}
 }
 
 // list secrets

--- a/pkg/vault/client.go
+++ b/pkg/vault/client.go
@@ -208,6 +208,9 @@ func ReadSecret(instanceAddr, secretPath, engineVersion string) map[string]inter
 	case KV_V1:
 		return raw.Data
 	case KV_V2:
+		if len(raw.Data) == 0 {
+			return nil
+		}
 		mapped, ok := raw.Data["data"].(map[string]interface{})
 		if !ok {
 			log.WithError(err).WithFields(log.Fields{

--- a/pkg/vault/reconcile.go
+++ b/pkg/vault/reconcile.go
@@ -169,6 +169,8 @@ func ParseDuration(duration string) (time.Duration, error) {
 // DataInSecret compare given data with data stored in the vault secret
 func DataInSecret(instanceAddr string, data map[string]interface{}, path string) bool {
 	// read desired secret
+	// KV V1 is harded coded as all logic related to calling DataInSecret is internal resource reconciliation
+	// vault utilizes KV V1 for storing this info
 	secret := ReadSecret(instanceAddr, path, KV_V1)
 	if secret == nil {
 		return false

--- a/pkg/vault/reconcile.go
+++ b/pkg/vault/reconcile.go
@@ -164,7 +164,7 @@ func ParseDuration(duration string) (time.Duration, error) {
 // DataInSecret compare given data with data stored in the vault secret
 func DataInSecret(instanceAddr string, data map[string]interface{}, path string) bool {
 	// read desired secret
-	secret := ReadSecret(instanceAddr, path)
+	secret := ReadSecret(instanceAddr, path, KV_V1)
 	if secret == nil {
 		return false
 	}
@@ -179,7 +179,7 @@ func DataInSecret(instanceAddr string, data map[string]interface{}, path string)
 			continue
 		}
 
-		if fmt.Sprintf("%v", secret.Data[k]) == fmt.Sprintf("%v", v) {
+		if fmt.Sprintf("%v", secret[k]) == fmt.Sprintf("%v", v) {
 			continue
 		}
 		return false

--- a/pkg/vault/reconcile.go
+++ b/pkg/vault/reconcile.go
@@ -17,6 +17,11 @@ type Item interface {
 	KeyForType() string
 }
 
+const (
+	OIDC_CLIENT_SECRET        = "oidc_client_secret"
+	OIDC_CLIENT_SECRET_KV_VER = "oidc_client_secret_kv_version"
+)
+
 // DiffItems is a pure function that determines what changes need to be made to
 // a Vault instance in order to reach the desired state.
 func DiffItems(desired, existing []Item) (toBeWritten, toBeDeleted, toBeUpdated []Item) {
@@ -30,14 +35,17 @@ func DiffItems(desired, existing []Item) (toBeWritten, toBeDeleted, toBeUpdated 
 	}
 
 	if len(existing) == 0 && len(desired) != 0 {
+		fmt.Println("LEN FAIL")
 		toBeWritten = desired
 	} else {
 		for _, item := range desired {
 			itemType := item.KeyForType()
 			if !in(item, existing) {
 				if !deepComparisonForName(item.Key(), existingNames) {
+					fmt.Println("DEEP NAME FAIL")
 					toBeWritten = append(toBeWritten, item)
 				} else if !keyDescription(item, existing) && itemType == "kv" {
+					fmt.Println("DESCRIPTION FAIL")
 					toBeUpdated = append(toBeUpdated, item)
 				} else if (itemType == "entity" || itemType == "entity-alias" || itemType == "group") &&
 					deepComparisonForName(item.Key(), existingNames) {
@@ -175,7 +183,7 @@ func DataInSecret(instanceAddr string, data map[string]interface{}, path string)
 				log.WithError(err).WithField("option", k).Fatal("failed to parse duration from data")
 			}
 			v = int64(dur.Seconds())
-		} else if k == "oidc_client_secret" { // not returned from ReadSecret()
+		} else if k == OIDC_CLIENT_SECRET || k == OIDC_CLIENT_SECRET_KV_VER { // not returned from ReadSecret()
 			continue
 		}
 

--- a/pkg/vault/reconcile.go
+++ b/pkg/vault/reconcile.go
@@ -35,17 +35,14 @@ func DiffItems(desired, existing []Item) (toBeWritten, toBeDeleted, toBeUpdated 
 	}
 
 	if len(existing) == 0 && len(desired) != 0 {
-		fmt.Println("LEN FAIL")
 		toBeWritten = desired
 	} else {
 		for _, item := range desired {
 			itemType := item.KeyForType()
 			if !in(item, existing) {
 				if !deepComparisonForName(item.Key(), existingNames) {
-					fmt.Println("DEEP NAME FAIL")
 					toBeWritten = append(toBeWritten, item)
 				} else if !keyDescription(item, existing) && itemType == "kv" {
-					fmt.Println("DESCRIPTION FAIL")
 					toBeUpdated = append(toBeUpdated, item)
 				} else if (itemType == "entity" || itemType == "entity-alias" || itemType == "group") &&
 					deepComparisonForName(item.Key(), existingNames) {

--- a/query.graphql
+++ b/query.graphql
@@ -28,10 +28,15 @@
           ttl
         }
         ... on VaultAuthConfigOidc_v1 {
+          default_role
           oidc_discovery_url
           oidc_client_id
-          oidc_client_secret
-          default_role
+          oidc_client_secret_kv_version
+          oidc_client_secret {
+            path
+            field
+            version
+          }
         }
       }
     }

--- a/tests/app-interface/data.json
+++ b/tests/app-interface/data.json
@@ -27,7 +27,7 @@
                     "$ref": "/common-1.json#/definitions/identifier"
                 },
                 "github_username": {
-                    "$ref": "/common-1.json#/definitions/identifier"
+                    "$ref": "/common-1.json#/definitions/botIdentifier"
                 },
                 "openshift_serviceaccount": {
                     "type": "string",
@@ -345,6 +345,13 @@
                                 "reporter",
                                 "guest"
                             ]
+                        },
+                        "pagerduty": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "/common-1.json#/definitions/crossref",
+                                "$schemaRef": "/dependencies/pagerduty-target-1.yml"
+                            }
                         }
                     },
                     "required": [
@@ -826,6 +833,11 @@
                 "description": {
                     "type": "string"
                 },
+                "repoUrl": {
+                    "type": "string",
+                    "description": "url of the app-interface git repository",
+                    "format": "uri"
+                },
                 "vault": {
                     "type": "boolean"
                 },
@@ -869,10 +881,32 @@
                         "mailAddress": {
                             "type": "string"
                         },
+                        "timeout": {
+                            "type": "integer"
+                        },
                         "credentials": {
                             "$ref": "/common-1.json#/definitions/vaultSecret"
                         }
-                    }
+                    },
+                    "required": [
+                        "mailAddress",
+                        "credentials"
+                    ]
+                },
+                "imap": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "timeout": {
+                            "type": "integer"
+                        },
+                        "credentials": {
+                            "$ref": "/common-1.json#/definitions/vaultSecret"
+                        }
+                    },
+                    "required": [
+                        "credentials"
+                    ]
                 },
                 "githubRepoInvites": {
                     "type": "object",
@@ -988,6 +1022,7 @@
                 "labels",
                 "name",
                 "description",
+                "repoUrl",
                 "vault",
                 "kubeBinary",
                 "saasDeployJobTemplate",
@@ -1097,6 +1132,9 @@
                     "type": "string",
                     "pattern": "(((\\d+,)+\\d+|(\\d+(\\/|-)\\d+)|\\d+|\\*) ?){5}"
                 },
+                "delete": {
+                    "type": "boolean"
+                },
                 "query": {
                     "$ref": "/common-1.json#/definitions/query"
                 },
@@ -1165,6 +1203,121 @@
                 "user",
                 "credentials"
             ]
+        },
+        "/app-interface/graphql-schemas-1.yml": {
+            "$schema": "/metaschema-1.json",
+            "version": "1.0",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "$schema": {
+                    "type": "string",
+                    "enum": [
+                        "/app-interface/graphql-schemas-1.yml"
+                    ]
+                },
+                "confs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/conf"
+                    }
+                }
+            },
+            "definitions": {
+                "conf": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "fields": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/field"
+                            }
+                        },
+                        "datafile": {
+                            "type": "string"
+                        },
+                        "isInterface": {
+                            "type": "boolean"
+                        },
+                        "interface": {
+                            "type": "string"
+                        },
+                        "interfaceResolve": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "strategy": {
+                                    "type": "string",
+                                    "enum": [
+                                        "fieldMap"
+                                    ]
+                                },
+                                "field": {
+                                    "type": "string"
+                                },
+                                "fieldMap": {
+                                    "type": "object",
+                                    "properties": {
+                                        "/": {}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "field": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string"
+                        },
+                        "isInterface": {
+                            "type": "boolean"
+                        },
+                        "isUnique": {
+                            "type": "boolean"
+                        },
+                        "isRequired": {
+                            "type": "boolean"
+                        },
+                        "isSearchable": {
+                            "type": "boolean"
+                        },
+                        "isList": {
+                            "type": "boolean"
+                        },
+                        "isResource": {
+                            "type": "boolean"
+                        },
+                        "resolveResource": {
+                            "type": "boolean"
+                        },
+                        "synthetic": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "schema": {
+                                    "type": "string"
+                                },
+                                "subAttr": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "datafileSchema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         },
         "/app-interface/prometheus-rule-test-1.yml": {
             "$schema": "/metaschema-1.json",
@@ -1313,6 +1466,61 @@
                 "tests"
             ]
         },
+        "/app-interface/query-validation-1.yml": {
+            "$schema": "/metaschema-1.json",
+            "version": "1.0",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "$schema": {
+                    "type": "string",
+                    "enum": [
+                        "/app-interface/query-validation-1.yml"
+                    ]
+                },
+                "labels": {
+                    "$ref": "/common-1.json#/definitions/labels"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "unique name for query validation"
+                },
+                "description": {
+                    "type": "string",
+                    "description": "description of the queries included in the file"
+                },
+                "escalationPolicy": {
+                    "$ref": "/common-1.json#/definitions/crossref",
+                    "$schemaRef": "/app-sre/escalation-policy-1.yml"
+                },
+                "queries": {
+                    "type": "array",
+                    "description": "queries to validate",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "path": {
+                                "$ref": "/common-1.json#/definitions/resourceref",
+                                "description": "path to resource query to be tested"
+                            }
+                        },
+                        "required": [
+                            "path"
+                        ]
+                    },
+                    "minItems": 1
+                }
+            },
+            "required": [
+                "$schema",
+                "labels",
+                "name",
+                "description",
+                "escalationPolicy",
+                "queries"
+            ]
+        },
         "/app-interface/template-test-1.yml": {
             "$schema": "/metaschema-1.json",
             "version": "1.0",
@@ -1415,7 +1623,7 @@
                 "architectureDocument": {
                     "type": "string",
                     "format": "uri",
-                    "description": "Link to the architectureDocument. This can be a git link or a link to a\nGoogle Doc.\n"
+                    "description": "The Architecture Document should be written with SREs as the target audience. Anyone\nreading the Architecture Document should understand how the service works, even\nwithout any prior background. This document will be the primary reference during\nincidents. To ensure the Architecture Document is always accessible to SREs and its\nchanges properly reviewed and tracked, it must be written in markdown and stored in\na place where SREs can control its changes.\n"
                 },
                 "parentApp": {
                     "$ref": "/common-1.json#/definitions/crossref",
@@ -1493,7 +1701,7 @@
                         "properties": {
                             "project": {
                                 "$ref": "/common-1.json#/definitions/crossref",
-                                "$schemaRef": "/dependencies/gcp-project-1.yml"
+                                "$schemaRef": "/gcp/project-1.yml"
                             },
                             "items": {
                                 "type": "array",
@@ -1763,6 +1971,11 @@
                             "jira": {
                                 "$ref": "/common-1.json#/definitions/crossref",
                                 "$schemaRef": "/dependencies/jira-server-1.yml"
+                            },
+                            "mirror": {
+                                "type": "string",
+                                "format": "uri",
+                                "description": "GitLab repo to mirror from"
                             }
                         },
                         "required": [
@@ -1977,40 +2190,6 @@
                 "name",
                 "description",
                 "source"
-            ]
-        },
-        "/app-sre/document-1.yml": {
-            "$schema": "/metaschema-1.json",
-            "version": "1.0",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "$schema": {
-                    "type": "string",
-                    "enum": [
-                        "/app-sre/document-1.yml"
-                    ]
-                },
-                "labels": {
-                    "$ref": "/common-1.json#/definitions/labels"
-                },
-                "app": {
-                    "$ref": "/common-1.json#/definitions/crossref",
-                    "$schemaRef": "/app-sre/app-1.yml"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "content_path": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "$schema",
-                "labels",
-                "app",
-                "name",
-                "content_path"
             ]
         },
         "/app-sre/environment-1.yml": {
@@ -2425,6 +2604,14 @@
                 "shards": {
                     "type": "integer",
                     "description": "number of shards to run integration with"
+                },
+                "shardingStrategy": {
+                    "type": "string",
+                    "description": "the strategy to use for sharding",
+                    "enum": [
+                        "per-aws-account",
+                        "static"
+                    ]
                 },
                 "sleepDurationSecs": {
                     "type": "integer",
@@ -2847,105 +3034,14 @@
                             "targets": {
                                 "type": "array",
                                 "items": {
-                                    "type": "object",
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "namespace": {
+                                    "oneOf": [
+                                        {
+                                            "$ref": "/app-sre/saas-file-target-1.yml"
+                                        },
+                                        {
                                             "$ref": "/common-1.json#/definitions/crossref",
-                                            "$schemaRef": "/openshift/namespace-1.yml"
-                                        },
-                                        "ref": {
-                                            "type": "string",
-                                            "pattern": "^([0-9a-f]{40}|master|main|internal|quayio)$"
-                                        },
-                                        "promotion": {
-                                            "type": "object",
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "auto": {
-                                                    "type": "boolean"
-                                                },
-                                                "publish": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "type": "string"
-                                                    },
-                                                    "minItems": 1
-                                                },
-                                                "subscribe": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "type": "string"
-                                                    },
-                                                    "minItems": 1
-                                                },
-                                                "promotion_data": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "type": "object",
-                                                        "properties": {
-                                                            "channel": {
-                                                                "type": "string"
-                                                            },
-                                                            "data": {
-                                                                "type": "array",
-                                                                "items": {
-                                                                    "type": "object",
-                                                                    "properties": {
-                                                                        "type": {
-                                                                            "type": "string"
-                                                                        }
-                                                                    },
-                                                                    "additionalProperties": true
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            },
-                                            "dependencies": {
-                                                "auto": [
-                                                    "subscribe"
-                                                ]
-                                            }
-                                        },
-                                        "parameters": {
-                                            "type": "object"
-                                        },
-                                        "secretParameters": {
-                                            "type": "array",
-                                            "description": "target level parameters from vault secrets",
-                                            "items": {
-                                                "$ref": "/app-sre/vault-secret-parameter-1.yml"
-                                            }
-                                        },
-                                        "upstream": {
-                                            "type": "object",
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "instance": {
-                                                    "$ref": "/common-1.json#/definitions/crossref",
-                                                    "$schemaRef": "/dependencies/jenkins-instance-1.yml"
-                                                },
-                                                "name": {
-                                                    "type": "string"
-                                                }
-                                            },
-                                            "required": [
-                                                "instance",
-                                                "name"
-                                            ]
-                                        },
-                                        "disable": {
-                                            "type": "boolean"
-                                        },
-                                        "delete": {
-                                            "type": "boolean"
+                                            "$schemaRef": "/app-sre/saas-file-target-1.yml"
                                         }
-                                    },
-                                    "required": [
-                                        "namespace",
-                                        "ref"
                                     ]
                                 }
                             }
@@ -2995,6 +3091,119 @@
                 "managedResourceTypes",
                 "resourceTemplates",
                 "imagePatterns"
+            ]
+        },
+        "/app-sre/saas-file-target-1.yml": {
+            "$schema": "/metaschema-1.json",
+            "version": "1.0",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "$schema": {
+                    "type": "string",
+                    "enum": [
+                        "/app-sre/saas-file-target-1.yml"
+                    ]
+                },
+                "namespace": {
+                    "$ref": "/common-1.json#/definitions/crossref",
+                    "$schemaRef": "/openshift/namespace-1.yml"
+                },
+                "ref": {
+                    "type": "string",
+                    "pattern": "^([0-9a-f]{40}|master|main|internal|quayio)$"
+                },
+                "promotion": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "auto": {
+                            "type": "boolean"
+                        },
+                        "publish": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "minItems": 1
+                        },
+                        "subscribe": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "minItems": 1
+                        },
+                        "promotion_data": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "channel": {
+                                        "type": "string"
+                                    },
+                                    "data": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "type": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "additionalProperties": true
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "dependencies": {
+                        "auto": [
+                            "subscribe"
+                        ]
+                    }
+                },
+                "parameters": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^[A-Za-z][A-Za-z0-9_]*$": {}
+                    }
+                },
+                "secretParameters": {
+                    "type": "array",
+                    "description": "target level parameters from vault secrets",
+                    "items": {
+                        "$ref": "/app-sre/vault-secret-parameter-1.yml"
+                    }
+                },
+                "upstream": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "instance": {
+                            "$ref": "/common-1.json#/definitions/crossref",
+                            "$schemaRef": "/dependencies/jenkins-instance-1.yml"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "instance",
+                        "name"
+                    ]
+                },
+                "disable": {
+                    "type": "boolean"
+                },
+                "delete": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "namespace",
+                "ref"
             ]
         },
         "/app-sre/schedule-1.yml": {
@@ -3073,6 +3282,10 @@
                 },
                 "name": {
                     "$ref": "/common-1.json#/definitions/identifier"
+                },
+                "app": {
+                    "$ref": "/common-1.json#/definitions/crossref",
+                    "$schemaRef": "/app-sre/app-1.yml"
                 },
                 "namespaces": {
                     "type": "array",
@@ -3178,7 +3391,8 @@
                 "labels",
                 "name",
                 "namespaces",
-                "slos"
+                "slos",
+                "app"
             ]
         },
         "/app-sre/sre-checkpoint-1.yml": {
@@ -3467,7 +3681,7 @@
                     ]
                 },
                 "name": {
-                    "type": "string",
+                    "pattern": "^[A-Za-z][A-Za-z0-9_]*$",
                     "description": "parameter name"
                 },
                 "secret": {
@@ -3579,12 +3793,13 @@
                     "properties": {
                         "integrations": {
                             "type": "array",
+                            "description": "integrations to disable for the aws account",
                             "items": {
                                 "type": "string",
                                 "enum": [
                                     "terraform-resources",
-                                    "terraform-resources-wrapper",
-                                    "terraform-users"
+                                    "terraform-users",
+                                    "terraform-aws-route53"
                                 ]
                             }
                         }
@@ -3632,6 +3847,11 @@
                     "items": {
                         "$ref": "/aws/sharing-option-1.yml"
                     }
+                },
+                "terraformState": {
+                    "description": "key information for a terraform's state location and integration",
+                    "$ref": "/common-1.json#/definitions/crossref",
+                    "$schemaRef": "/dependencies/terraform-state-1.yml"
                 }
             },
             "required": [
@@ -3675,7 +3895,7 @@
                         "type": "string"
                     }
                 },
-                "availability_zones": {
+                "vpc_zone_identifier": {
                     "type": "array",
                     "items": {
                         "type": "string"
@@ -3998,6 +4218,70 @@
                     "required": [
                         "enabled"
                     ]
+                },
+                "auth": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "admin_user_arn": {
+                            "description": "The ARN for the admin user.\nThis option is mutually exclusive with admin_user_credentials.\n",
+                            "type": "string"
+                        },
+                        "admin_user_credentials": {
+                            "description": "Secret containing the user/password authentication data. It must only\ncontain the \"master_user_name\" and \"master_user_password\" keys.\nThe admin user password must be at least 8 chars long, contain at least one\nuppercase letter, one lowercase letter, one number, and one special character.\nThis option is mutually exclusive with admin_user_arn.\n",
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "path": {
+                                    "type": "string"
+                                },
+                                "version": {
+                                    "type": "integer"
+                                }
+                            },
+                            "required": [
+                                "path",
+                                "version"
+                            ]
+                        }
+                    },
+                    "oneOf": [
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "admin_user_arn": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "admin_user_arn"
+                            ]
+                        },
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "admin_user_credentials": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "version": {
+                                            "type": "integer"
+                                        }
+                                    },
+                                    "required": [
+                                        "path",
+                                        "version"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "admin_user_credentials"
+                            ]
+                        }
+                    ]
                 }
             },
             "required": [
@@ -4281,170 +4565,13 @@
                 "$schema": {
                     "type": "string",
                     "enum": [
-                        "/aws/s3-1.yml"
+                        "/aws/regions-1.yml"
                     ]
                 },
                 "region": {
                     "type": "string"
                 }
             }
-        },
-        "/aws/s3-1.yml": {
-            "$schema": "/metaschema-1.json",
-            "version": "1.0",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "$schema": {
-                    "type": "string",
-                    "enum": [
-                        "/aws/s3-1.yml"
-                    ]
-                },
-                "provider": {
-                    "type": "string",
-                    "enum": [
-                        "s3",
-                        "s3-cloudfront",
-                        "s3-sqs"
-                    ]
-                },
-                "account": {
-                    "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
-                },
-                "region": {
-                    "$ref": "/aws/regions-1.yml#/properties/region"
-                },
-                "identifier": {
-                    "$ref": "/common-1.json#/definitions/longIdentifier"
-                },
-                "defaults": {
-                    "type": "string"
-                },
-                "overrides": {
-                    "type": "object",
-                    "properties": {
-                        "acl": {
-                            "type": "string",
-                            "enum": [
-                                "private",
-                                "public-read"
-                            ]
-                        }
-                    }
-                },
-                "event_notifications": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "event_type": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "destination": {
-                                "type": "string"
-                            },
-                            "destination_type": {
-                                "type": "string",
-                                "enum": [
-                                    "sns",
-                                    "sqs"
-                                ]
-                            },
-                            "filter_prefix": {
-                                "type": "string"
-                            },
-                            "filter_suffix": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                },
-                "sqs_identifier": {
-                    "type": "string"
-                },
-                "s3_events": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "versioning": {
-                    "type": "boolean"
-                },
-                "storage_class": {
-                    "type": "string",
-                    "enum": [
-                        "standard",
-                        "reduced_redundancy",
-                        "standard_ia",
-                        "onezone_ia",
-                        "intelligent_tiering",
-                        "glacier",
-                        "deep_archive"
-                    ]
-                },
-                "replication_configurations": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "rule_name": {
-                                "type": "string"
-                            },
-                            "destination_bucket_identifier": {
-                                "type": "string"
-                            },
-                            "status": {
-                                "type": "string",
-                                "enum": [
-                                    "enabled",
-                                    "disabled"
-                                ]
-                            },
-                            "storage_class": {
-                                "type": "string",
-                                "enum": [
-                                    "standard",
-                                    "reduced_redundancy",
-                                    "standard_ia",
-                                    "onezone_ia",
-                                    "intelligent_tiering",
-                                    "glacier",
-                                    "deep_archive"
-                                ]
-                            }
-                        },
-                        "required": [
-                            "rule_name",
-                            "destination_bucket_identifier"
-                        ]
-                    }
-                },
-                "bucket_policy": {
-                    "type": "object"
-                },
-                "output_resource_name": {
-                    "$ref": "/common-1.json#/definitions/longIdentifier"
-                },
-                "output_format": {
-                    "$ref": "/openshift/terraform-output-format-1.yml"
-                },
-                "allow_object_tagging": {
-                    "type": "boolean"
-                },
-                "kms_encryption": {
-                    "type": "boolean"
-                }
-            },
-            "required": [
-                "account",
-                "identifier",
-                "defaults"
-            ]
         },
         "/aws/sharing-option-1.yml": {
             "$schema": "/metaschema-1.json",
@@ -4530,6 +4657,1723 @@
             },
             "required": [
                 "account"
+            ]
+        },
+        "/aws/terraform-resource-2.yml": {
+            "$schema": "/metaschema-1.json",
+            "version": "1.0",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "$schema": {
+                    "type": "string",
+                    "enum": [
+                        "/aws/terraform-resource-2.yml"
+                    ]
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "/common-1.json#/definitions/annotations"
+                },
+                "identifier": {
+                    "$ref": "/common-1.json#/definitions/longIdentifier"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "variables": {
+                    "type": "object"
+                },
+                "policies": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "policy": {
+                    "type": "object"
+                },
+                "fifo_topic": {
+                    "type": "boolean"
+                },
+                "user_policy": {
+                    "type": "object"
+                },
+                "assume_role": {
+                    "type": "object"
+                },
+                "assume_condition": {
+                    "type": "object"
+                },
+                "inline_policy": {
+                    "type": "object"
+                },
+                "output_resource_name": {
+                    "$ref": "/common-1.json#/definitions/longIdentifier"
+                },
+                "output_format": {
+                    "$ref": "/openshift/terraform-output-format-1.yml"
+                },
+                "defaults": {
+                    "type": "string"
+                },
+                "parameter_group": {
+                    "type": "string"
+                },
+                "region": {
+                    "$ref": "/aws/regions-1.yml#/properties/region"
+                },
+                "overrides": {
+                    "type": "object"
+                },
+                "es_identifier": {
+                    "type": "string"
+                },
+                "availability_zone": {
+                    "type": "string"
+                },
+                "enhanced_monitoring": {
+                    "type": "boolean"
+                },
+                "replica_source": {
+                    "type": "string"
+                },
+                "output_resource_db_name": {
+                    "type": "string"
+                },
+                "reset_password": {
+                    "type": "string"
+                },
+                "ca_cert": {
+                    "$ref": "/common-1.json#/definitions/vaultSecret"
+                },
+                "secret": {
+                    "$ref": "/common-1.json#/definitions/vaultSecret"
+                },
+                "storage_class": {
+                    "type": "string"
+                },
+                "specs": {
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    }
+                },
+                "s3_events": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "event_notifications": {
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    }
+                },
+                "sqs_identifier": {
+                    "type": "string"
+                },
+                "bucket_policy": {
+                    "type": "object"
+                },
+                "kms_encryption": {
+                    "type": "boolean"
+                },
+                "mirror": {
+                    "$schemaRef": "/dependencies/container-image-mirror-1.yml"
+                },
+                "public": {
+                    "type": "boolean"
+                },
+                "domain": {
+                    "type": "object"
+                },
+                "aws_infrastructure_access": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "cluster": {
+                            "$ref": "/common-1.json#/definitions/crossref",
+                            "$schemaRef": "/openshift/cluster-1.yml"
+                        },
+                        "access_level": {
+                            "type": "string"
+                        },
+                        "assume_role": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "vpc": {
+                    "$ref": "/common-1.json#/definitions/crossref",
+                    "$schemaRef": "/aws/vpc-1.yml"
+                },
+                "certificate_arn": {
+                    "type": "string"
+                },
+                "idle_timeout": {
+                    "type": "integer"
+                },
+                "targets": {
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    }
+                },
+                "rules": {
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    }
+                },
+                "cloudinit_configs": {
+                    "type": "array",
+                    "items": {
+                        "type": "object"
+                    }
+                },
+                "publish_log_types": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "upstream": {
+                            "type": "object",
+                            "properties": {
+                                "instance": {
+                                    "$ref": "/common-1.json#/definitions/crossref",
+                                    "$schemaRef": "/dependencies/jenkins-instance-1.yml"
+                                }
+                            }
+                        }
+                    }
+                },
+                "secrets_prefix": {
+                    "type": "string"
+                },
+                "api_proxy_uri": {
+                    "type": "string"
+                },
+                "sms_role_ext_id": {
+                    "type": "string"
+                },
+                "cognito_callback_bucket_name": {
+                    "type": "string"
+                },
+                "vpc_arn": {
+                    "type": "string"
+                },
+                "vpc_id": {
+                    "type": "string"
+                },
+                "vpce_id": {
+                    "type": "string"
+                },
+                "subnet_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "domain_name": {
+                    "type": "string"
+                },
+                "network_interface_ids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "openshift_ingress_load_balancer_arn": {
+                    "type": "string"
+                },
+                "pre_signup_lambda_github_release_url": {
+                    "type": "string"
+                },
+                "subscriptions": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "protocol": {
+                                "type": "string",
+                                "enum": [
+                                    "email"
+                                ]
+                            },
+                            "endpoint": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "oneOf": [
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "$schema": {
+                            "type": "string",
+                            "enum": [
+                                "/aws/s3-1.yml"
+                            ]
+                        },
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "s3",
+                                "s3-cloudfront",
+                                "s3-sqs"
+                            ]
+                        },
+                        "region": {
+                            "$ref": "/aws/regions-1.yml#/properties/region"
+                        },
+                        "identifier": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "defaults": {
+                            "$ref": "/common-1.json#/definitions/resourceref"
+                        },
+                        "overrides": {
+                            "type": "object",
+                            "properties": {
+                                "acl": {
+                                    "type": "string",
+                                    "enum": [
+                                        "private",
+                                        "public-read"
+                                    ]
+                                }
+                            }
+                        },
+                        "event_notifications": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "event_type": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "destination": {
+                                        "type": "string"
+                                    },
+                                    "destination_type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "sns",
+                                            "sqs"
+                                        ]
+                                    },
+                                    "filter_prefix": {
+                                        "type": "string"
+                                    },
+                                    "filter_suffix": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        },
+                        "sqs_identifier": {
+                            "type": "string"
+                        },
+                        "s3_events": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "versioning": {
+                            "type": "boolean"
+                        },
+                        "storage_class": {
+                            "type": "string",
+                            "enum": [
+                                "standard",
+                                "reduced_redundancy",
+                                "standard_ia",
+                                "onezone_ia",
+                                "intelligent_tiering",
+                                "glacier",
+                                "deep_archive"
+                            ]
+                        },
+                        "replication_configurations": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "rule_name": {
+                                        "type": "string"
+                                    },
+                                    "destination_bucket_identifier": {
+                                        "type": "string"
+                                    },
+                                    "status": {
+                                        "type": "string",
+                                        "enum": [
+                                            "enabled",
+                                            "disabled"
+                                        ]
+                                    },
+                                    "storage_class": {
+                                        "type": "string",
+                                        "enum": [
+                                            "standard",
+                                            "reduced_redundancy",
+                                            "standard_ia",
+                                            "onezone_ia",
+                                            "intelligent_tiering",
+                                            "glacier",
+                                            "deep_archive"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "rule_name",
+                                    "destination_bucket_identifier"
+                                ]
+                            }
+                        },
+                        "bucket_policy": {
+                            "type": "object"
+                        },
+                        "output_resource_name": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_format": {
+                            "$ref": "/openshift/terraform-output-format-1.yml"
+                        },
+                        "allow_object_tagging": {
+                            "type": "boolean"
+                        },
+                        "kms_encryption": {
+                            "type": "boolean"
+                        }
+                    },
+                    "required": [
+                        "identifier",
+                        "defaults"
+                    ]
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "aws-iam-service-account"
+                            ]
+                        },
+                        "identifier": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "variables": {
+                            "type": "object"
+                        },
+                        "policies": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "user_policy": {
+                            "type": "object"
+                        },
+                        "output_resource_name": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_format": {
+                            "$ref": "/openshift/terraform-output-format-1.yml"
+                        },
+                        "aws_infrastructure_access": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "cluster": {
+                                    "$ref": "/common-1.json#/definitions/crossref",
+                                    "$schemaRef": "/openshift/cluster-1.yml"
+                                },
+                                "access_level": {
+                                    "type": "string"
+                                },
+                                "assume_role": {
+                                    "type": "string"
+                                }
+                            },
+                            "oneOf": [
+                                {
+                                    "required": [
+                                        "cluster",
+                                        "access_level"
+                                    ]
+                                },
+                                {
+                                    "required": [
+                                        "assume_role"
+                                    ]
+                                }
+                            ]
+                        },
+                        "annotations": {
+                            "$ref": "/common-1.json#/definitions/annotations"
+                        }
+                    },
+                    "required": [
+                        "identifier"
+                    ]
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "secrets-manager-service-account"
+                            ]
+                        },
+                        "identifier": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "secrets_prefix": {
+                            "type": "string"
+                        },
+                        "output_resource_name": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_format": {
+                            "$ref": "/openshift/terraform-output-format-1.yml"
+                        },
+                        "annotations": {
+                            "$ref": "/common-1.json#/definitions/annotations"
+                        }
+                    },
+                    "required": [
+                        "identifier",
+                        "secrets_prefix"
+                    ]
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "aws-iam-role"
+                            ]
+                        },
+                        "identifier": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "assume_role": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "AWS": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "Service": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "anyOf": [
+                                {
+                                    "required": [
+                                        "AWS"
+                                    ]
+                                },
+                                {
+                                    "required": [
+                                        "Service"
+                                    ]
+                                }
+                            ]
+                        },
+                        "assume_condition": {
+                            "description": "condition context keys for IAM and AWS STS",
+                            "type": "object"
+                        },
+                        "inline_policy": {
+                            "type": "object"
+                        },
+                        "output_resource_name": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_format": {
+                            "$ref": "/openshift/terraform-output-format-1.yml"
+                        },
+                        "annotations": {
+                            "$ref": "/common-1.json#/definitions/annotations"
+                        }
+                    },
+                    "required": [
+                        "identifier",
+                        "assume_role"
+                    ]
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "rds"
+                            ]
+                        },
+                        "region": {
+                            "$ref": "/aws/regions-1.yml#/properties/region"
+                        },
+                        "identifier": {
+                            "type": "string"
+                        },
+                        "availability_zone": {
+                            "type": "string"
+                        },
+                        "defaults": {
+                            "$ref": "/common-1.json#/definitions/resourceref"
+                        },
+                        "parameter_group": {
+                            "type": "string"
+                        },
+                        "overrides": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "engine": {
+                                    "type": "string",
+                                    "enum": [
+                                        "postgres",
+                                        "mysql"
+                                    ]
+                                },
+                                "engine_version": {
+                                    "type": "string"
+                                },
+                                "username": {
+                                    "type": "string"
+                                },
+                                "instance_class": {
+                                    "type": "string",
+                                    "enum": [
+                                        "db.t2.micro",
+                                        "db.t2.small",
+                                        "db.t3.small",
+                                        "db.m3.medium",
+                                        "db.t3.medium",
+                                        "db.m4.large",
+                                        "db.m4.xlarge",
+                                        "db.m4.2xlarge",
+                                        "db.m5.large",
+                                        "db.m5.xlarge",
+                                        "db.m5.2xlarge",
+                                        "db.m5.4xlarge",
+                                        "db.m5.8xlarge",
+                                        "db.m5.12xlarge",
+                                        "db.m5.16xlarge",
+                                        "db.m5.24xlarge",
+                                        "db.m6g.large",
+                                        "db.m6g.xlarge",
+                                        "db.m6g.2xlarge",
+                                        "db.m6g.4xlarge",
+                                        "db.m6g.8xlarge",
+                                        "db.m6g.12xlarge",
+                                        "db.m6g.16xlarge",
+                                        "db.r4.large",
+                                        "db.r4.xlarge",
+                                        "db.r4.2xlarge",
+                                        "db.r4.4xlarge",
+                                        "db.r4.8xlarge",
+                                        "db.r4.16xlarge",
+                                        "db.r5.large",
+                                        "db.r5.xlarge",
+                                        "db.r5.2xlarge",
+                                        "db.r5.4xlarge",
+                                        "db.r5.8xlarge",
+                                        "db.r5.12xlarge",
+                                        "db.r5.16xlarge",
+                                        "db.r5.24xlarge"
+                                    ]
+                                },
+                                "allocated_storage": {
+                                    "type": "integer"
+                                },
+                                "backup_retention_period": {
+                                    "type": "integer"
+                                },
+                                "storage_encrypted": {
+                                    "type": "boolean"
+                                },
+                                "monitoring_interval": {
+                                    "type": "integer"
+                                },
+                                "allow_major_version_upgrade": {
+                                    "type": "boolean"
+                                },
+                                "timeouts": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "create": {
+                                            "type": "string"
+                                        },
+                                        "update": {
+                                            "type": "string"
+                                        },
+                                        "delete": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "output_resource_name": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_format": {
+                            "$ref": "/openshift/terraform-output-format-1.yml"
+                        },
+                        "output_resource_db_name": {
+                            "type": "string"
+                        },
+                        "reset_password": {
+                            "type": "string"
+                        },
+                        "enhanced_monitoring": {
+                            "type": "boolean"
+                        },
+                        "replica_source": {
+                            "type": "string"
+                        },
+                        "ca_cert": {
+                            "$ref": "/common-1.json#/definitions/vaultSecret"
+                        },
+                        "annotations": {
+                            "$ref": "/common-1.json#/definitions/annotations"
+                        },
+                        "event_notifications": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "destination": {
+                                        "type": "string"
+                                    },
+                                    "source_type": {
+                                        "type": "string",
+                                        "enum": [
+                                            "db-instance",
+                                            "db-security-group",
+                                            "db-parameter-group",
+                                            "db-snapshot",
+                                            "db-cluster",
+                                            "db-cluster-snapshot"
+                                        ]
+                                    },
+                                    "event_categories": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "required": [
+                        "identifier",
+                        "defaults"
+                    ]
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "elasticache"
+                            ]
+                        },
+                        "identifier": {
+                            "type": "string"
+                        },
+                        "defaults": {
+                            "$ref": "/common-1.json#/definitions/resourceref"
+                        },
+                        "parameter_group": {
+                            "type": "string"
+                        },
+                        "region": {
+                            "$ref": "/aws/regions-1.yml#/properties/region"
+                        },
+                        "overrides": {
+                            "type": "object",
+                            "properties": {
+                                "engine": {
+                                    "type": "string",
+                                    "enum": [
+                                        "redis"
+                                    ]
+                                },
+                                "engine_version": {
+                                    "type": "string"
+                                },
+                                "node_type": {
+                                    "type": "string",
+                                    "enum": [
+                                        "cache.m5.large",
+                                        "cache.m5.xlarge",
+                                        "cache.m5.2xlarge",
+                                        "cache.r5.large",
+                                        "cache.r5.xlarge",
+                                        "cache.r5.2xlarge",
+                                        "cache.r3.xlarge"
+                                    ]
+                                },
+                                "port": {
+                                    "type": "integer"
+                                }
+                            }
+                        },
+                        "output_resource_name": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_format": {
+                            "$ref": "/openshift/terraform-output-format-1.yml"
+                        },
+                        "annotations": {
+                            "$ref": "/common-1.json#/definitions/annotations"
+                        }
+                    },
+                    "required": [
+                        "identifier",
+                        "defaults"
+                    ]
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "sqs"
+                            ]
+                        },
+                        "region": {
+                            "$ref": "/aws/regions-1.yml#/properties/region"
+                        },
+                        "identifier": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_resource_name": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_format": {
+                            "$ref": "/openshift/terraform-output-format-1.yml"
+                        },
+                        "annotations": {
+                            "$ref": "/common-1.json#/definitions/annotations"
+                        },
+                        "specs": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "defaults": {
+                                        "$ref": "/common-1.json#/definitions/resourceref"
+                                    },
+                                    "queues": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "key": {
+                                                    "$ref": "/common-1.json#/definitions/secretKey"
+                                                },
+                                                "value": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "required": [
+                                    "defaults",
+                                    "queues"
+                                ]
+                            }
+                        }
+                    },
+                    "required": [
+                        "identifier",
+                        "specs"
+                    ]
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "sns"
+                            ]
+                        },
+                        "defaults": {
+                            "$ref": "/common-1.json#/definitions/resourceref"
+                        },
+                        "region": {
+                            "$ref": "/aws/regions-1.yml#/properties/region"
+                        },
+                        "identifier": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_resource_name": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_format": {
+                            "$ref": "/openshift/terraform-output-format-1.yml"
+                        },
+                        "fifo_topic": {
+                            "type": "boolean"
+                        },
+                        "inline_policy": {
+                            "type": "object"
+                        },
+                        "annotations": {
+                            "$ref": "/common-1.json#/definitions/annotations"
+                        },
+                        "subscriptions": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "protocol": {
+                                        "type": "string",
+                                        "enum": [
+                                            "email"
+                                        ]
+                                    },
+                                    "endpoint": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "required": [
+                        "identifier",
+                        "defaults"
+                    ]
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "dynamodb"
+                            ]
+                        },
+                        "region": {
+                            "$ref": "/aws/regions-1.yml#/properties/region"
+                        },
+                        "identifier": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_resource_name": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_format": {
+                            "$ref": "/openshift/terraform-output-format-1.yml"
+                        },
+                        "annotations": {
+                            "$ref": "/common-1.json#/definitions/annotations"
+                        },
+                        "specs": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "defaults": {
+                                        "$ref": "/common-1.json#/definitions/resourceref"
+                                    },
+                                    "tables": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "properties": {
+                                                "key": {
+                                                    "$ref": "/common-1.json#/definitions/secretKey"
+                                                },
+                                                "value": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "required": [
+                                    "defaults",
+                                    "tables"
+                                ]
+                            }
+                        }
+                    },
+                    "required": [
+                        "identifier",
+                        "specs"
+                    ]
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "ecr"
+                            ]
+                        },
+                        "region": {
+                            "$ref": "/aws/regions-1.yml#/properties/region"
+                        },
+                        "identifier": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_resource_name": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_format": {
+                            "$ref": "/openshift/terraform-output-format-1.yml"
+                        },
+                        "mirror": {
+                            "$schemaRef": "/dependencies/container-image-mirror-1.yml"
+                        },
+                        "public": {
+                            "type": "boolean"
+                        }
+                    },
+                    "required": [
+                        "identifier"
+                    ]
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "cloudwatch"
+                            ]
+                        },
+                        "region": {
+                            "$ref": "/aws/regions-1.yml#/properties/region"
+                        },
+                        "identifier": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "es_identifier": {
+                            "type": "string"
+                        },
+                        "filter_pattern": {
+                            "type": "string"
+                        },
+                        "output_resource_name": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_format": {
+                            "$ref": "/openshift/terraform-output-format-1.yml"
+                        },
+                        "defaults": {
+                            "$ref": "/common-1.json#/definitions/resourceref"
+                        },
+                        "annotations": {
+                            "$ref": "/common-1.json#/definitions/annotations"
+                        }
+                    },
+                    "required": [
+                        "identifier",
+                        "defaults"
+                    ]
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "kms"
+                            ]
+                        },
+                        "identifier": {
+                            "type": "string"
+                        },
+                        "region": {
+                            "$ref": "/aws/regions-1.yml#/properties/region"
+                        },
+                        "defaults": {
+                            "$ref": "/common-1.json#/definitions/resourceref"
+                        },
+                        "overrides": {
+                            "type": "object",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                                "key_usage": {
+                                    "type": "string",
+                                    "enum": [
+                                        "encrypt_decrypt",
+                                        "sign_verify"
+                                    ]
+                                },
+                                "deletion_window_in_days": {
+                                    "type": "integer"
+                                },
+                                "enable_key_rotation": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "output_resource_name": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_format": {
+                            "$ref": "/openshift/terraform-output-format-1.yml"
+                        },
+                        "annotations": {
+                            "$ref": "/common-1.json#/definitions/annotations"
+                        }
+                    },
+                    "required": [
+                        "identifier",
+                        "defaults"
+                    ]
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "elasticsearch"
+                            ]
+                        },
+                        "region": {
+                            "$ref": "/aws/regions-1.yml#/properties/region"
+                        },
+                        "identifier": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_resource_name": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_format": {
+                            "$ref": "/openshift/terraform-output-format-1.yml"
+                        },
+                        "defaults": {
+                            "$ref": "/common-1.json#/definitions/resourceref"
+                        },
+                        "annotations": {
+                            "$ref": "/common-1.json#/definitions/annotations"
+                        },
+                        "publish_log_types": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": [
+                                    "INDEX_SLOW_LOGS",
+                                    "SEARCH_SLOW_LOGS",
+                                    "ES_APPLICATION_LOGS"
+                                ]
+                            }
+                        }
+                    },
+                    "required": [
+                        "identifier",
+                        "defaults"
+                    ]
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "acm"
+                            ]
+                        },
+                        "region": {
+                            "$ref": "/aws/regions-1.yml#/properties/region"
+                        },
+                        "identifier": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "secret": {
+                            "$ref": "/common-1.json#/definitions/vaultSecret"
+                        },
+                        "domain": {
+                            "type": "object",
+                            "properties": {
+                                "domain_name": {
+                                    "type": "string"
+                                },
+                                "alternate_names": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "required": [
+                                "domain_name"
+                            ]
+                        },
+                        "output_resource_name": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_format": {
+                            "$ref": "/openshift/terraform-output-format-1.yml"
+                        },
+                        "annotations": {
+                            "$ref": "/common-1.json#/definitions/annotations"
+                        }
+                    },
+                    "required": [
+                        "identifier"
+                    ],
+                    "oneOf": [
+                        {
+                            "required": [
+                                "secret"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "domain"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "kinesis"
+                            ]
+                        },
+                        "identifier": {
+                            "type": "string"
+                        },
+                        "region": {
+                            "$ref": "/aws/regions-1.yml#/properties/region"
+                        },
+                        "defaults": {
+                            "$ref": "/common-1.json#/definitions/resourceref"
+                        },
+                        "output_resource_name": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_format": {
+                            "$ref": "/openshift/terraform-output-format-1.yml"
+                        },
+                        "annotations": {
+                            "$ref": "/common-1.json#/definitions/annotations"
+                        }
+                    },
+                    "required": [
+                        "identifier",
+                        "defaults"
+                    ]
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "s3-cloudfront-public-key"
+                            ]
+                        },
+                        "region": {
+                            "$ref": "/aws/regions-1.yml#/properties/region"
+                        },
+                        "identifier": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "secret": {
+                            "$ref": "/common-1.json#/definitions/vaultSecret"
+                        },
+                        "output_resource_name": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_format": {
+                            "$ref": "/openshift/terraform-output-format-1.yml"
+                        },
+                        "annotations": {
+                            "$ref": "/common-1.json#/definitions/annotations"
+                        }
+                    },
+                    "required": [
+                        "identifier",
+                        "secret"
+                    ]
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "alb"
+                            ]
+                        },
+                        "identifier": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_resource_name": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_format": {
+                            "$ref": "/openshift/terraform-output-format-1.yml"
+                        },
+                        "region": {
+                            "$ref": "/aws/regions-1.yml#/properties/region"
+                        },
+                        "vpc": {
+                            "$ref": "/common-1.json#/definitions/crossref",
+                            "$schemaRef": "/aws/vpc-1.yml"
+                        },
+                        "certificate_arn": {
+                            "type": "string"
+                        },
+                        "idle_timeout": {
+                            "type": "integer"
+                        },
+                        "targets": {
+                            "type": "array",
+                            "minItems": 2,
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "default": {
+                                        "type": "boolean"
+                                    },
+                                    "ips": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "openshift_service": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "name",
+                                    "default"
+                                ],
+                                "oneOf": [
+                                    {
+                                        "required": [
+                                            "ips"
+                                        ]
+                                    },
+                                    {
+                                        "required": [
+                                            "openshift_service"
+                                        ]
+                                    }
+                                ]
+                            }
+                        },
+                        "rules": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "condition": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "path": {
+                                                "type": "string"
+                                            },
+                                            "methods": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                        "GET",
+                                                        "HEAD",
+                                                        "OPTIONS",
+                                                        "POST",
+                                                        "PUT",
+                                                        "PATCH",
+                                                        "DELETE"
+                                                    ]
+                                                }
+                                            }
+                                        },
+                                        "required": [
+                                            "path"
+                                        ]
+                                    },
+                                    "action": {
+                                        "type": "array",
+                                        "minItems": 2,
+                                        "items": {
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "properties": {
+                                                "target": {
+                                                    "type": "string"
+                                                },
+                                                "weight": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "required": [
+                                                "target",
+                                                "weight"
+                                            ]
+                                        }
+                                    }
+                                },
+                                "required": [
+                                    "condition",
+                                    "action"
+                                ]
+                            }
+                        },
+                        "annotations": {
+                            "$ref": "/common-1.json#/definitions/annotations"
+                        }
+                    },
+                    "required": [
+                        "identifier",
+                        "vpc",
+                        "certificate_arn",
+                        "targets",
+                        "rules"
+                    ]
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "secrets-manager"
+                            ]
+                        },
+                        "region": {
+                            "$ref": "/aws/regions-1.yml#/properties/region"
+                        },
+                        "identifier": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "secret": {
+                            "$ref": "/common-1.json#/definitions/vaultSecret"
+                        },
+                        "output_resource_name": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_format": {
+                            "$ref": "/openshift/terraform-output-format-1.yml"
+                        },
+                        "annotations": {
+                            "$ref": "/common-1.json#/definitions/annotations"
+                        }
+                    },
+                    "required": [
+                        "identifier",
+                        "secret"
+                    ]
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "asg"
+                            ]
+                        },
+                        "region": {
+                            "$ref": "/aws/regions-1.yml#/properties/region"
+                        },
+                        "identifier": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "defaults": {
+                            "$ref": "/common-1.json#/definitions/resourceref"
+                        },
+                        "cloudinit_configs": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "filename": {
+                                        "type": "string"
+                                    },
+                                    "content_type": {
+                                        "type": "string"
+                                    },
+                                    "content": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "content"
+                                ]
+                            }
+                        },
+                        "variables": {
+                            "type": "object"
+                        },
+                        "image": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "tag_name": {
+                                    "description": "name of tag to use to correlate AMI ID to commit",
+                                    "type": "string"
+                                },
+                                "url": {
+                                    "description": "url of source code repository",
+                                    "type": "string",
+                                    "format": "uri"
+                                },
+                                "ref": {
+                                    "description": "commit or branch name",
+                                    "type": "string",
+                                    "pattern": "^([0-9a-f]{40}|master|main)$"
+                                },
+                                "upstream": {
+                                    "description": "jenkins instance and job to wait for",
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "instance": {
+                                            "$ref": "/common-1.json#/definitions/crossref",
+                                            "$schemaRef": "/dependencies/jenkins-instance-1.yml"
+                                        },
+                                        "name": {
+                                            "description": "name of jenkins job to wait for",
+                                            "type": "string"
+                                        }
+                                    },
+                                    "required": [
+                                        "instance",
+                                        "name"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "tag_name",
+                                "url",
+                                "ref"
+                            ]
+                        },
+                        "output_resource_name": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_format": {
+                            "$ref": "/openshift/terraform-output-format-1.yml"
+                        },
+                        "annotations": {
+                            "$ref": "/common-1.json#/definitions/annotations"
+                        }
+                    },
+                    "required": [
+                        "identifier",
+                        "defaults",
+                        "image"
+                    ]
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "route53-zone"
+                            ]
+                        },
+                        "identifier": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "description": "base fqdn of the zone",
+                            "$ref": "/common-1.json#/definitions/k8sValidContainerName"
+                        },
+                        "region": {
+                            "$ref": "/aws/regions-1.yml#/properties/region"
+                        },
+                        "output_resource_name": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "output_format": {
+                            "$ref": "/openshift/terraform-output-format-1.yml"
+                        },
+                        "annotations": {
+                            "$ref": "/common-1.json#/definitions/annotations"
+                        }
+                    },
+                    "required": [
+                        "identifier",
+                        "name"
+                    ]
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "rosa-authenticator"
+                            ]
+                        },
+                        "identifier": {
+                            "type": "string"
+                        },
+                        "api_proxy_uri": {
+                            "type": "string"
+                        },
+                        "sms_role_ext_id": {
+                            "type": "string"
+                        },
+                        "cognito_callback_bucket_name": {
+                            "type": "string"
+                        },
+                        "pre_signup_lambda_github_release_url": {
+                            "type": "string"
+                        },
+                        "vpc_arn": {
+                            "type": "string"
+                        },
+                        "vpc_id": {
+                            "type": "string"
+                        },
+                        "vpce_id": {
+                            "type": "string"
+                        },
+                        "subnet_ids": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "network_interface_ids": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "openshift_ingress_load_balancer_arn": {
+                            "type": "string"
+                        },
+                        "certificate_arn": {
+                            "type": "string"
+                        },
+                        "domain_name": {
+                            "type": "string"
+                        },
+                        "defaults": {
+                            "$ref": "/common-1.json#/definitions/resourceref"
+                        },
+                        "region": {
+                            "$ref": "/aws/regions-1.yml#/properties/region"
+                        },
+                        "output_resource_name": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "annotations": {
+                            "$ref": "/common-1.json#/definitions/annotations"
+                        }
+                    },
+                    "required": [
+                        "identifier",
+                        "api_proxy_uri",
+                        "cognito_callback_bucket_name",
+                        "certificate_arn",
+                        "domain_name",
+                        "vpc_id",
+                        "subnet_ids",
+                        "defaults"
+                    ]
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "rosa-authenticator-vpce"
+                            ]
+                        },
+                        "annotations": {
+                            "$ref": "/common-1.json#/definitions/annotations"
+                        },
+                        "defaults": {
+                            "$ref": "/common-1.json#/definitions/resourceref"
+                        },
+                        "identifier": {
+                            "type": "string"
+                        },
+                        "output_format": {
+                            "$ref": "/openshift/terraform-output-format-1.yml"
+                        },
+                        "output_resource_name": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "region": {
+                            "type": "string"
+                        },
+                        "subnet_ids": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "vpc_id": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "defaults",
+                        "identifier",
+                        "vpc_id",
+                        "subnet_ids"
+                    ]
+                }
+            ],
+            "required": [
+                "provider"
             ]
         },
         "/aws/vpc-1.yml": {
@@ -5162,47 +7006,6 @@
                 "provider"
             ]
         },
-        "/dependencies/gcp-project-1.yml": {
-            "$schema": "/metaschema-1.json",
-            "version": "1.0",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "$schema": {
-                    "type": "string",
-                    "enum": [
-                        "/dependencies/gcp-project-1.yml"
-                    ]
-                },
-                "labels": {
-                    "$ref": "/common-1.json#/definitions/labels"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "managedTeams": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "description": {
-                    "type": "string"
-                },
-                "automationToken": {
-                    "$ref": "/common-1.json#/definitions/vaultSecret"
-                },
-                "pushCredentials": {
-                    "$ref": "/common-1.json#/definitions/vaultSecret"
-                }
-            },
-            "required": [
-                "$schema",
-                "labels",
-                "name",
-                "description"
-            ]
-        },
         "/dependencies/github-org-1.yml": {
             "$schema": "/metaschema-1.json",
             "version": "1.0",
@@ -5372,7 +7175,7 @@
                     ]
                 },
                 "config_path": {
-                    "type": "string"
+                    "$ref": "/common-1.json#/definitions/resourceref"
                 },
                 "config": {
                     "type": "array",
@@ -5632,6 +7435,9 @@
                     "required": [
                         "workspace"
                     ]
+                },
+                "issueResolveState": {
+                    "type": "string"
                 }
             },
             "required": [
@@ -6469,6 +8275,152 @@
                 "provider"
             ]
         },
+        "/dependencies/terraform-state-1.yml": {
+            "$schema": "/metaschema-1.json",
+            "version": "1.0",
+            "type": "object",
+            "description": "bucket properties for each integration",
+            "additionalProperties": false,
+            "properties": {
+                "$schema": {
+                    "type": "string",
+                    "enum": [
+                        "/dependencies/terraform-state-1.yml"
+                    ]
+                },
+                "provider": {
+                    "type": "string",
+                    "enum": [
+                        "s3"
+                    ]
+                },
+                "bucket": {
+                    "type": "string"
+                },
+                "region": {
+                    "type": "string"
+                },
+                "integrations": {
+                    "type": "array",
+                    "description": "holds information which bucket key stores the terraform state per integration",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "integration": {
+                                "type": "string"
+                            },
+                            "key": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                }
+            }
+        },
+        "/gcp/project-1.yml": {
+            "$schema": "/metaschema-1.json",
+            "version": "1.0",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "$schema": {
+                    "type": "string",
+                    "enum": [
+                        "/gcp/project-1.yml"
+                    ]
+                },
+                "labels": {
+                    "$ref": "/common-1.json#/definitions/labels"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "managedTeams": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "description": {
+                    "type": "string"
+                },
+                "automationToken": {
+                    "$ref": "/common-1.json#/definitions/vaultSecret"
+                },
+                "pushCredentials": {
+                    "$ref": "/common-1.json#/definitions/vaultSecret"
+                }
+            },
+            "required": [
+                "$schema",
+                "labels",
+                "name",
+                "description"
+            ]
+        },
+        "/gcp/terraform-resource-1.yml": {
+            "$schema": "/metaschema-1.json",
+            "version": "1.0",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "$schema": {
+                    "type": "string",
+                    "enum": [
+                        "/gcp/terraform-resource-1.yml"
+                    ]
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "annotations": {
+                    "$ref": "/common-1.json#/definitions/annotations"
+                },
+                "identifier": {
+                    "$ref": "/common-1.json#/definitions/longIdentifier"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "output_resource_name": {
+                    "$ref": "/common-1.json#/definitions/longIdentifier"
+                }
+            },
+            "oneOf": [
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "dns-zone"
+                            ]
+                        },
+                        "identifier": {
+                            "type": "string"
+                        },
+                        "name": {
+                            "description": "base fqdn of the zone",
+                            "$ref": "/common-1.json#/definitions/k8sValidContainerName"
+                        },
+                        "output_resource_name": {
+                            "$ref": "/common-1.json#/definitions/longIdentifier"
+                        },
+                        "annotations": {
+                            "$ref": "/common-1.json#/definitions/annotations"
+                        }
+                    },
+                    "required": [
+                        "identifier",
+                        "name"
+                    ]
+                }
+            ],
+            "required": [
+                "provider"
+            ]
+        },
         "/kafka/cluster-1.yml": {
             "$schema": "/metaschema-1.json",
             "version": "1.0",
@@ -6665,6 +8617,9 @@
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
+                        "product": {
+                            "type": "string"
+                        },
                         "id": {
                             "type": "string"
                         },
@@ -6758,15 +8713,14 @@
                         }
                     },
                     "required": [
+                        "product",
                         "provider",
                         "region",
                         "version",
                         "initial_version",
                         "multi_az",
                         "instance_type",
-                        "private",
-                        "storage",
-                        "load_balancers"
+                        "private"
                     ],
                     "oneOf": [
                         {
@@ -7201,31 +9155,8 @@
                     "type": "boolean"
                 },
                 "jumpHost": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "hostname": {
-                            "type": "string",
-                            "format": "uri"
-                        },
-                        "knownHosts": {
-                            "type": "string"
-                        },
-                        "user": {
-                            "type": "string"
-                        },
-                        "port": {
-                            "type": "integer"
-                        },
-                        "identity": {
-                            "$ref": "/common-1.json#/definitions/vaultSecret"
-                        }
-                    },
-                    "required": [
-                        "hostname",
-                        "user",
-                        "identity"
-                    ]
+                    "$ref": "/common-1.json#/definitions/crossref",
+                    "$schemaRef": "/openshift/jump-host-1.yml"
                 },
                 "automationToken": {
                     "$ref": "/common-1.json#/definitions/vaultSecret"
@@ -7261,8 +9192,7 @@
                                     "openshift-resourcequotas",
                                     "openshift-limitranges",
                                     "openshift-serviceaccount-tokens",
-                                    "terraform-resources",
-                                    "terraform-resources-wrapper"
+                                    "terraform-resources"
                                 ]
                             }
                         },
@@ -7460,6 +9390,136 @@
                         "limits"
                     ]
                 }
+            ]
+        },
+        "/openshift/external-resource-1.yml": {
+            "$schema": "/metaschema-1.json",
+            "version": "1.0",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "$schema": {
+                    "type": "string",
+                    "enum": [
+                        "/openshift/external-resource-1.yml"
+                    ]
+                },
+                "provider": {
+                    "type": "string",
+                    "description": "terraform provider type to use",
+                    "enum": [
+                        "aws",
+                        "gcp-project"
+                    ]
+                },
+                "provisioner": {
+                    "$ref": "/common-1.json#/definitions/crossref",
+                    "description": "the provisioning entity"
+                },
+                "resources": {
+                    "type": "array",
+                    "description": "resources to provision",
+                    "items": {
+                        "oneOf": [
+                            {
+                                "$ref": "/aws/terraform-resource-2.yml"
+                            },
+                            {
+                                "$ref": "/gcp/terraform-resource-1.yml"
+                            }
+                        ]
+                    }
+                }
+            },
+            "oneOf": [
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "aws"
+                            ]
+                        },
+                        "provisioner": {
+                            "$ref": "/common-1.json#/definitions/crossref",
+                            "$schemaRef": "/aws/account-1.yml"
+                        },
+                        "resources": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "/aws/terraform-resource-2.yml"
+                            }
+                        }
+                    }
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "provider": {
+                            "type": "string",
+                            "enum": [
+                                "gcp-project"
+                            ]
+                        },
+                        "provisioner": {
+                            "$ref": "/common-1.json#/definitions/crossref",
+                            "$schemaRef": "/gcp/project-1.yml"
+                        },
+                        "resources": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "/gcp/terraform-resource-1.yml"
+                            }
+                        }
+                    }
+                }
+            ],
+            "required": [
+                "provider",
+                "provisioner",
+                "resources"
+            ]
+        },
+        "/openshift/jump-host-1.yml": {
+            "$schema": "/metaschema-1.json",
+            "version": "1.0",
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "$schema": {
+                    "type": "string",
+                    "enum": [
+                        "/openshift/jump-host-1.yml"
+                    ]
+                },
+                "labels": {
+                    "$ref": "/common-1.json#/definitions/labels"
+                },
+                "hostname": {
+                    "type": "string",
+                    "format": "uri"
+                },
+                "knownHosts": {
+                    "$ref": "/common-1.json#/definitions/resourceref"
+                },
+                "user": {
+                    "type": "string"
+                },
+                "port": {
+                    "type": "integer"
+                },
+                "identity": {
+                    "$ref": "/common-1.json#/definitions/vaultSecret"
+                }
+            },
+            "required": [
+                "$schema",
+                "labels",
+                "hostname",
+                "knownHosts",
+                "user",
+                "identity"
             ]
         },
         "/openshift/limitrange-1.yml": {
@@ -7767,13 +9827,15 @@
                         "$ref": "/openshift/openshift-resource-1.yml"
                     }
                 },
-                "managedTerraformResources": {
-                    "type": "boolean"
+                "managedExternalResources": {
+                    "type": "boolean",
+                    "description": "are external resources managed for this namespace"
                 },
-                "terraformResources": {
+                "externalResources": {
                     "type": "array",
+                    "description": "external resources to provision for this namespace",
                     "items": {
-                        "$ref": "/openshift/terraform-resource-1.yml"
+                        "$ref": "/openshift/external-resource-1.yml"
                     }
                 },
                 "openshiftServiceAccountTokens": {
@@ -7804,16 +9866,16 @@
                 }
             },
             "dependencies": {
-                "terraformResources": {
+                "externalResources": {
                     "properties": {
-                        "managedTerraformResources": {
+                        "managedExternalResources": {
                             "enum": [
                                 true
                             ]
                         }
                     },
                     "required": [
-                        "managedTerraformResources"
+                        "managedExternalResources"
                     ]
                 }
             },
@@ -7947,7 +10009,7 @@
                             ]
                         },
                         "path": {
-                            "type": "string"
+                            "$ref": "/common-1.json#/definitions/resourceref"
                         },
                         "validate_json": {
                             "type": "boolean"
@@ -7973,7 +10035,7 @@
                             ]
                         },
                         "path": {
-                            "type": "string"
+                            "$ref": "/common-1.json#/definitions/resourceref"
                         },
                         "type": {
                             "type": "string",
@@ -8006,7 +10068,7 @@
                             ]
                         },
                         "path": {
-                            "type": "string"
+                            "$ref": "/common-1.json#/definitions/resourceref"
                         },
                         "vault_tls_secret_path": {
                             "type": "string"
@@ -8214,6 +10276,9 @@
                                                                     "type": "string"
                                                                 },
                                                                 "team": {
+                                                                    "type": "string"
+                                                                },
+                                                                "code": {
                                                                     "type": "string"
                                                                 },
                                                                 "component": {
@@ -8562,12 +10627,6 @@
                             "serviceAccountName"
                         ]
                     }
-                },
-                "terraformResources": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "/openshift/terraform-resource-1.yml"
-                    }
                 }
             },
             "required": [
@@ -8629,1373 +10688,6 @@
                         "provider"
                     ]
                 }
-            ]
-        },
-        "/openshift/terraform-resource-1.yml": {
-            "$schema": "/metaschema-1.json",
-            "version": "1.0",
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "$schema": {
-                    "type": "string",
-                    "enum": [
-                        "/openshift/terraform-resource-1.yml"
-                    ]
-                },
-                "provider": {
-                    "type": "string"
-                },
-                "annotations": {
-                    "$ref": "/common-1.json#/definitions/annotations"
-                },
-                "account": {
-                    "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
-                },
-                "identifier": {
-                    "$ref": "/common-1.json#/definitions/longIdentifier"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "variables": {
-                    "type": "object"
-                },
-                "policies": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "policy": {
-                    "type": "object"
-                },
-                "fifo_topic": {
-                    "type": "boolean"
-                },
-                "user_policy": {
-                    "type": "object"
-                },
-                "assume_role": {
-                    "type": "object"
-                },
-                "assume_condition": {
-                    "type": "object"
-                },
-                "inline_policy": {
-                    "type": "object"
-                },
-                "output_resource_name": {
-                    "$ref": "/common-1.json#/definitions/longIdentifier"
-                },
-                "output_format": {
-                    "$ref": "/openshift/terraform-output-format-1.yml"
-                },
-                "defaults": {
-                    "type": "string"
-                },
-                "parameter_group": {
-                    "type": "string"
-                },
-                "region": {
-                    "$ref": "/aws/regions-1.yml#/properties/region"
-                },
-                "overrides": {
-                    "type": "object"
-                },
-                "es_identifier": {
-                    "type": "string"
-                },
-                "availability_zone": {
-                    "type": "string"
-                },
-                "enhanced_monitoring": {
-                    "type": "boolean"
-                },
-                "replica_source": {
-                    "type": "string"
-                },
-                "output_resource_db_name": {
-                    "type": "string"
-                },
-                "reset_password": {
-                    "type": "string"
-                },
-                "ca_cert": {
-                    "$ref": "/common-1.json#/definitions/vaultSecret"
-                },
-                "secret": {
-                    "$ref": "/common-1.json#/definitions/vaultSecret"
-                },
-                "storage_class": {
-                    "type": "string"
-                },
-                "specs": {
-                    "type": "array",
-                    "items": {
-                        "type": "object"
-                    }
-                },
-                "s3_events": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "event_notifications": {
-                    "type": "array",
-                    "items": {
-                        "type": "object"
-                    }
-                },
-                "sqs_identifier": {
-                    "type": "string"
-                },
-                "bucket_policy": {
-                    "type": "object"
-                },
-                "kms_encryption": {
-                    "type": "boolean"
-                },
-                "mirror": {
-                    "$schemaRef": "/dependencies/container-image-mirror-1.yml"
-                },
-                "public": {
-                    "type": "boolean"
-                },
-                "domain": {
-                    "type": "object"
-                },
-                "aws_infrastructure_access": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "cluster": {
-                            "$ref": "/common-1.json#/definitions/crossref",
-                            "$schemaRef": "/openshift/cluster-1.yml"
-                        },
-                        "access_level": {
-                            "type": "string"
-                        },
-                        "assume_role": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "vpc": {
-                    "$ref": "/common-1.json#/definitions/crossref",
-                    "$schemaRef": "/aws/vpc-1.yml"
-                },
-                "certificate_arn": {
-                    "type": "string"
-                },
-                "idle_timeout": {
-                    "type": "integer"
-                },
-                "targets": {
-                    "type": "array",
-                    "items": {
-                        "type": "object"
-                    }
-                },
-                "rules": {
-                    "type": "array",
-                    "items": {
-                        "type": "object"
-                    }
-                },
-                "cloudinit_configs": {
-                    "type": "array",
-                    "items": {
-                        "type": "object"
-                    }
-                },
-                "publish_log_types": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "image": {
-                    "type": "object",
-                    "properties": {
-                        "upstream": {
-                            "type": "object",
-                            "properties": {
-                                "instance": {
-                                    "$ref": "/common-1.json#/definitions/crossref",
-                                    "$schemaRef": "/dependencies/jenkins-instance-1.yml"
-                                }
-                            }
-                        }
-                    }
-                },
-                "secrets_prefix": {
-                    "type": "string"
-                }
-            },
-            "oneOf": [
-                {
-                    "$ref": "/aws/s3-1.yml"
-                },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "provider": {
-                            "type": "string",
-                            "enum": [
-                                "aws-iam-service-account"
-                            ]
-                        },
-                        "account": {
-                            "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
-                        },
-                        "identifier": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "variables": {
-                            "type": "object"
-                        },
-                        "policies": {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "user_policy": {
-                            "type": "object"
-                        },
-                        "output_resource_name": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "output_format": {
-                            "$ref": "/openshift/terraform-output-format-1.yml"
-                        },
-                        "aws_infrastructure_access": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                                "cluster": {
-                                    "$ref": "/common-1.json#/definitions/crossref",
-                                    "$schemaRef": "/openshift/cluster-1.yml"
-                                },
-                                "access_level": {
-                                    "type": "string"
-                                },
-                                "assume_role": {
-                                    "type": "string"
-                                }
-                            },
-                            "oneOf": [
-                                {
-                                    "required": [
-                                        "cluster",
-                                        "access_level"
-                                    ]
-                                },
-                                {
-                                    "required": [
-                                        "assume_role"
-                                    ]
-                                }
-                            ]
-                        },
-                        "annotations": {
-                            "$ref": "/common-1.json#/definitions/annotations"
-                        }
-                    },
-                    "required": [
-                        "account",
-                        "identifier"
-                    ]
-                },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "provider": {
-                            "type": "string",
-                            "enum": [
-                                "secrets-manager-service-account"
-                            ]
-                        },
-                        "account": {
-                            "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
-                        },
-                        "identifier": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "secrets_prefix": {
-                            "type": "string"
-                        },
-                        "output_resource_name": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "output_format": {
-                            "$ref": "/openshift/terraform-output-format-1.yml"
-                        },
-                        "annotations": {
-                            "$ref": "/common-1.json#/definitions/annotations"
-                        }
-                    },
-                    "required": [
-                        "account",
-                        "identifier",
-                        "secrets_prefix"
-                    ]
-                },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "provider": {
-                            "type": "string",
-                            "enum": [
-                                "aws-iam-role"
-                            ]
-                        },
-                        "account": {
-                            "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
-                        },
-                        "identifier": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "assume_role": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                                "AWS": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                },
-                                "Service": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "anyOf": [
-                                {
-                                    "required": [
-                                        "AWS"
-                                    ]
-                                },
-                                {
-                                    "required": [
-                                        "Service"
-                                    ]
-                                }
-                            ]
-                        },
-                        "assume_condition": {
-                            "description": "condition context keys for IAM and AWS STS",
-                            "type": "object"
-                        },
-                        "inline_policy": {
-                            "type": "object"
-                        },
-                        "output_resource_name": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "output_format": {
-                            "$ref": "/openshift/terraform-output-format-1.yml"
-                        },
-                        "annotations": {
-                            "$ref": "/common-1.json#/definitions/annotations"
-                        }
-                    },
-                    "required": [
-                        "account",
-                        "identifier",
-                        "assume_role"
-                    ]
-                },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "provider": {
-                            "type": "string",
-                            "enum": [
-                                "rds"
-                            ]
-                        },
-                        "account": {
-                            "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
-                        },
-                        "region": {
-                            "$ref": "/aws/regions-1.yml#/properties/region"
-                        },
-                        "identifier": {
-                            "type": "string"
-                        },
-                        "availability_zone": {
-                            "type": "string"
-                        },
-                        "defaults": {
-                            "type": "string"
-                        },
-                        "parameter_group": {
-                            "type": "string"
-                        },
-                        "overrides": {
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                },
-                                "engine": {
-                                    "type": "string",
-                                    "enum": [
-                                        "postgres",
-                                        "mysql"
-                                    ]
-                                },
-                                "engine_version": {
-                                    "type": "string"
-                                },
-                                "username": {
-                                    "type": "string"
-                                },
-                                "instance_class": {
-                                    "type": "string",
-                                    "enum": [
-                                        "db.t2.micro",
-                                        "db.t2.small",
-                                        "db.t3.small",
-                                        "db.m3.medium",
-                                        "db.t3.medium",
-                                        "db.m4.large",
-                                        "db.m4.xlarge",
-                                        "db.m4.2xlarge",
-                                        "db.m5.large",
-                                        "db.m5.xlarge",
-                                        "db.m5.2xlarge",
-                                        "db.m6g.large",
-                                        "db.r4.large",
-                                        "db.r4.xlarge",
-                                        "db.r4.2xlarge",
-                                        "db.r4.4xlarge",
-                                        "db.r4.8xlarge",
-                                        "db.r4.16xlarge",
-                                        "db.r5.large",
-                                        "db.r5.xlarge",
-                                        "db.r5.2xlarge"
-                                    ]
-                                },
-                                "allocated_storage": {
-                                    "type": "integer"
-                                },
-                                "backup_retention_period": {
-                                    "type": "integer"
-                                },
-                                "storage_encrypted": {
-                                    "type": "boolean"
-                                },
-                                "monitoring_interval": {
-                                    "type": "integer"
-                                },
-                                "allow_major_version_upgrade": {
-                                    "type": "boolean"
-                                },
-                                "timeouts": {
-                                    "type": "object",
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "create": {
-                                            "type": "string"
-                                        },
-                                        "update": {
-                                            "type": "string"
-                                        },
-                                        "delete": {
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        "output_resource_name": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "output_format": {
-                            "$ref": "/openshift/terraform-output-format-1.yml"
-                        },
-                        "output_resource_db_name": {
-                            "type": "string"
-                        },
-                        "reset_password": {
-                            "type": "string"
-                        },
-                        "enhanced_monitoring": {
-                            "type": "boolean"
-                        },
-                        "replica_source": {
-                            "type": "string"
-                        },
-                        "ca_cert": {
-                            "$ref": "/common-1.json#/definitions/vaultSecret"
-                        },
-                        "annotations": {
-                            "$ref": "/common-1.json#/definitions/annotations"
-                        }
-                    },
-                    "required": [
-                        "account",
-                        "identifier",
-                        "defaults"
-                    ]
-                },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "provider": {
-                            "type": "string",
-                            "enum": [
-                                "elasticache"
-                            ]
-                        },
-                        "account": {
-                            "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
-                        },
-                        "identifier": {
-                            "type": "string"
-                        },
-                        "defaults": {
-                            "type": "string"
-                        },
-                        "parameter_group": {
-                            "type": "string"
-                        },
-                        "region": {
-                            "$ref": "/aws/regions-1.yml#/properties/region"
-                        },
-                        "overrides": {
-                            "type": "object",
-                            "properties": {
-                                "engine": {
-                                    "type": "string",
-                                    "enum": [
-                                        "redis"
-                                    ]
-                                },
-                                "engine_version": {
-                                    "type": "string"
-                                },
-                                "node_type": {
-                                    "type": "string",
-                                    "enum": [
-                                        "cache.m5.large",
-                                        "cache.m5.xlarge",
-                                        "cache.m5.2xlarge",
-                                        "cache.r5.large",
-                                        "cache.r5.xlarge",
-                                        "cache.r5.2xlarge",
-                                        "cache.r3.xlarge"
-                                    ]
-                                },
-                                "port": {
-                                    "type": "integer"
-                                }
-                            }
-                        },
-                        "output_resource_name": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "output_format": {
-                            "$ref": "/openshift/terraform-output-format-1.yml"
-                        },
-                        "annotations": {
-                            "$ref": "/common-1.json#/definitions/annotations"
-                        }
-                    },
-                    "required": [
-                        "account",
-                        "identifier",
-                        "defaults"
-                    ]
-                },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "provider": {
-                            "type": "string",
-                            "enum": [
-                                "sqs"
-                            ]
-                        },
-                        "account": {
-                            "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
-                        },
-                        "region": {
-                            "$ref": "/aws/regions-1.yml#/properties/region"
-                        },
-                        "identifier": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "output_resource_name": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "output_format": {
-                            "$ref": "/openshift/terraform-output-format-1.yml"
-                        },
-                        "annotations": {
-                            "$ref": "/common-1.json#/definitions/annotations"
-                        },
-                        "specs": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "defaults": {
-                                        "type": "string"
-                                    },
-                                    "queues": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "object",
-                                            "properties": {
-                                                "key": {
-                                                    "$ref": "/common-1.json#/definitions/secretKey"
-                                                },
-                                                "value": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "required": [
-                                    "defaults",
-                                    "queues"
-                                ]
-                            }
-                        }
-                    },
-                    "required": [
-                        "account",
-                        "identifier",
-                        "specs"
-                    ]
-                },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "provider": {
-                            "type": "string",
-                            "enum": [
-                                "dynamodb"
-                            ]
-                        },
-                        "account": {
-                            "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
-                        },
-                        "region": {
-                            "$ref": "/aws/regions-1.yml#/properties/region"
-                        },
-                        "identifier": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "output_resource_name": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "output_format": {
-                            "$ref": "/openshift/terraform-output-format-1.yml"
-                        },
-                        "annotations": {
-                            "$ref": "/common-1.json#/definitions/annotations"
-                        },
-                        "specs": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "defaults": {
-                                        "type": "string"
-                                    },
-                                    "tables": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "object",
-                                            "properties": {
-                                                "key": {
-                                                    "$ref": "/common-1.json#/definitions/secretKey"
-                                                },
-                                                "value": {
-                                                    "type": "string"
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                "required": [
-                                    "defaults",
-                                    "tables"
-                                ]
-                            }
-                        }
-                    },
-                    "required": [
-                        "account",
-                        "identifier",
-                        "specs"
-                    ]
-                },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "provider": {
-                            "type": "string",
-                            "enum": [
-                                "ecr"
-                            ]
-                        },
-                        "account": {
-                            "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
-                        },
-                        "region": {
-                            "$ref": "/aws/regions-1.yml#/properties/region"
-                        },
-                        "identifier": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "output_resource_name": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "output_format": {
-                            "$ref": "/openshift/terraform-output-format-1.yml"
-                        },
-                        "mirror": {
-                            "$schemaRef": "/dependencies/container-image-mirror-1.yml"
-                        },
-                        "public": {
-                            "type": "boolean"
-                        }
-                    },
-                    "required": [
-                        "account",
-                        "identifier"
-                    ]
-                },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "provider": {
-                            "type": "string",
-                            "enum": [
-                                "cloudwatch"
-                            ]
-                        },
-                        "account": {
-                            "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
-                        },
-                        "region": {
-                            "$ref": "/aws/regions-1.yml#/properties/region"
-                        },
-                        "identifier": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "es_identifier": {
-                            "type": "string"
-                        },
-                        "filter_pattern": {
-                            "type": "string"
-                        },
-                        "output_resource_name": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "output_format": {
-                            "$ref": "/openshift/terraform-output-format-1.yml"
-                        },
-                        "defaults": {
-                            "type": "string"
-                        },
-                        "annotations": {
-                            "$ref": "/common-1.json#/definitions/annotations"
-                        }
-                    },
-                    "required": [
-                        "account",
-                        "identifier",
-                        "defaults"
-                    ]
-                },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "provider": {
-                            "type": "string",
-                            "enum": [
-                                "kms"
-                            ]
-                        },
-                        "account": {
-                            "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
-                        },
-                        "identifier": {
-                            "type": "string"
-                        },
-                        "region": {
-                            "$ref": "/aws/regions-1.yml#/properties/region"
-                        },
-                        "defaults": {
-                            "type": "string"
-                        },
-                        "overrides": {
-                            "type": "object",
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                },
-                                "key_usage": {
-                                    "type": "string",
-                                    "enum": [
-                                        "encrypt_decrypt",
-                                        "sign_verify"
-                                    ]
-                                },
-                                "deletion_window_in_days": {
-                                    "type": "integer"
-                                },
-                                "enable_key_rotation": {
-                                    "type": "boolean"
-                                }
-                            }
-                        },
-                        "output_resource_name": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "output_format": {
-                            "$ref": "/openshift/terraform-output-format-1.yml"
-                        },
-                        "annotations": {
-                            "$ref": "/common-1.json#/definitions/annotations"
-                        }
-                    },
-                    "required": [
-                        "account",
-                        "identifier",
-                        "defaults"
-                    ]
-                },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "provider": {
-                            "type": "string",
-                            "enum": [
-                                "elasticsearch"
-                            ]
-                        },
-                        "region": {
-                            "$ref": "/aws/regions-1.yml#/properties/region"
-                        },
-                        "account": {
-                            "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
-                        },
-                        "identifier": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "output_resource_name": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "output_format": {
-                            "$ref": "/openshift/terraform-output-format-1.yml"
-                        },
-                        "defaults": {
-                            "type": "string"
-                        },
-                        "annotations": {
-                            "$ref": "/common-1.json#/definitions/annotations"
-                        },
-                        "publish_log_types": {
-                            "type": "array",
-                            "items": {
-                                "type": "string",
-                                "enum": [
-                                    "INDEX_SLOW_LOGS",
-                                    "SEARCH_SLOW_LOGS",
-                                    "ES_APPLICATION_LOGS"
-                                ]
-                            }
-                        }
-                    },
-                    "required": [
-                        "account",
-                        "identifier",
-                        "defaults"
-                    ]
-                },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "provider": {
-                            "type": "string",
-                            "enum": [
-                                "acm"
-                            ]
-                        },
-                        "region": {
-                            "$ref": "/aws/regions-1.yml#/properties/region"
-                        },
-                        "account": {
-                            "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
-                        },
-                        "identifier": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "secret": {
-                            "$ref": "/common-1.json#/definitions/vaultSecret"
-                        },
-                        "domain": {
-                            "type": "object",
-                            "properties": {
-                                "domain_name": {
-                                    "type": "string"
-                                },
-                                "alternate_names": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "required": [
-                                "domain_name"
-                            ]
-                        },
-                        "output_resource_name": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "output_format": {
-                            "$ref": "/openshift/terraform-output-format-1.yml"
-                        },
-                        "annotations": {
-                            "$ref": "/common-1.json#/definitions/annotations"
-                        }
-                    },
-                    "required": [
-                        "account",
-                        "identifier"
-                    ],
-                    "oneOf": [
-                        {
-                            "required": [
-                                "secret"
-                            ]
-                        },
-                        {
-                            "required": [
-                                "domain"
-                            ]
-                        }
-                    ]
-                },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "provider": {
-                            "type": "string",
-                            "enum": [
-                                "kinesis"
-                            ]
-                        },
-                        "account": {
-                            "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
-                        },
-                        "identifier": {
-                            "type": "string"
-                        },
-                        "region": {
-                            "$ref": "/aws/regions-1.yml#/properties/region"
-                        },
-                        "defaults": {
-                            "type": "string"
-                        },
-                        "output_resource_name": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "output_format": {
-                            "$ref": "/openshift/terraform-output-format-1.yml"
-                        },
-                        "annotations": {
-                            "$ref": "/common-1.json#/definitions/annotations"
-                        }
-                    },
-                    "required": [
-                        "account",
-                        "identifier",
-                        "defaults"
-                    ]
-                },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "provider": {
-                            "type": "string",
-                            "enum": [
-                                "s3-cloudfront-public-key"
-                            ]
-                        },
-                        "region": {
-                            "$ref": "/aws/regions-1.yml#/properties/region"
-                        },
-                        "account": {
-                            "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
-                        },
-                        "identifier": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "secret": {
-                            "$ref": "/common-1.json#/definitions/vaultSecret"
-                        },
-                        "output_resource_name": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "output_format": {
-                            "$ref": "/openshift/terraform-output-format-1.yml"
-                        },
-                        "annotations": {
-                            "$ref": "/common-1.json#/definitions/annotations"
-                        }
-                    },
-                    "required": [
-                        "account",
-                        "identifier",
-                        "secret"
-                    ]
-                },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "provider": {
-                            "type": "string",
-                            "enum": [
-                                "alb"
-                            ]
-                        },
-                        "account": {
-                            "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
-                        },
-                        "identifier": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "output_resource_name": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "output_format": {
-                            "$ref": "/openshift/terraform-output-format-1.yml"
-                        },
-                        "region": {
-                            "$ref": "/aws/regions-1.yml#/properties/region"
-                        },
-                        "vpc": {
-                            "$ref": "/common-1.json#/definitions/crossref",
-                            "$schemaRef": "/aws/vpc-1.yml"
-                        },
-                        "certificate_arn": {
-                            "type": "string"
-                        },
-                        "idle_timeout": {
-                            "type": "integer"
-                        },
-                        "targets": {
-                            "type": "array",
-                            "minItems": 2,
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "name": {
-                                        "type": "string"
-                                    },
-                                    "default": {
-                                        "type": "boolean"
-                                    },
-                                    "ips": {
-                                        "type": "array",
-                                        "items": {
-                                            "type": "string"
-                                        }
-                                    },
-                                    "openshift_service": {
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "name",
-                                    "default"
-                                ],
-                                "oneOf": [
-                                    {
-                                        "required": [
-                                            "ips"
-                                        ]
-                                    },
-                                    {
-                                        "required": [
-                                            "openshift_service"
-                                        ]
-                                    }
-                                ]
-                            }
-                        },
-                        "rules": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "condition": {
-                                        "type": "object",
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "path": {
-                                                "type": "string"
-                                            },
-                                            "methods": {
-                                                "type": "array",
-                                                "items": {
-                                                    "type": "string",
-                                                    "enum": [
-                                                        "GET",
-                                                        "HEAD",
-                                                        "OPTIONS",
-                                                        "POST",
-                                                        "PUT",
-                                                        "PATCH",
-                                                        "DELETE"
-                                                    ]
-                                                }
-                                            }
-                                        },
-                                        "required": [
-                                            "path"
-                                        ]
-                                    },
-                                    "action": {
-                                        "type": "array",
-                                        "minItems": 2,
-                                        "items": {
-                                            "type": "object",
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "target": {
-                                                    "type": "string"
-                                                },
-                                                "weight": {
-                                                    "type": "integer"
-                                                }
-                                            },
-                                            "required": [
-                                                "target",
-                                                "weight"
-                                            ]
-                                        }
-                                    }
-                                },
-                                "required": [
-                                    "condition",
-                                    "action"
-                                ]
-                            }
-                        },
-                        "annotations": {
-                            "$ref": "/common-1.json#/definitions/annotations"
-                        }
-                    },
-                    "required": [
-                        "account",
-                        "identifier",
-                        "vpc",
-                        "certificate_arn",
-                        "targets",
-                        "rules"
-                    ]
-                },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "provider": {
-                            "type": "string",
-                            "enum": [
-                                "secrets-manager"
-                            ]
-                        },
-                        "region": {
-                            "$ref": "/aws/regions-1.yml#/properties/region"
-                        },
-                        "account": {
-                            "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
-                        },
-                        "identifier": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "secret": {
-                            "$ref": "/common-1.json#/definitions/vaultSecret"
-                        },
-                        "output_resource_name": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "output_format": {
-                            "$ref": "/openshift/terraform-output-format-1.yml"
-                        },
-                        "annotations": {
-                            "$ref": "/common-1.json#/definitions/annotations"
-                        }
-                    },
-                    "required": [
-                        "account",
-                        "identifier",
-                        "secret"
-                    ]
-                },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "provider": {
-                            "type": "string",
-                            "enum": [
-                                "asg"
-                            ]
-                        },
-                        "region": {
-                            "$ref": "/aws/regions-1.yml#/properties/region"
-                        },
-                        "account": {
-                            "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
-                        },
-                        "identifier": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "defaults": {
-                            "type": "string"
-                        },
-                        "cloudinit_configs": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "filename": {
-                                        "type": "string"
-                                    },
-                                    "content_type": {
-                                        "type": "string"
-                                    },
-                                    "content": {
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "content"
-                                ]
-                            }
-                        },
-                        "variables": {
-                            "type": "object"
-                        },
-                        "image": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "properties": {
-                                "tag_name": {
-                                    "description": "name of tag to use to correlate AMI ID to commit",
-                                    "type": "string"
-                                },
-                                "url": {
-                                    "description": "url of source code repository",
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "ref": {
-                                    "description": "commit or branch name",
-                                    "type": "string",
-                                    "pattern": "^([0-9a-f]{40}|master|main)$"
-                                },
-                                "upstream": {
-                                    "description": "jenkins instance and job to wait for",
-                                    "type": "object",
-                                    "additionalProperties": false,
-                                    "properties": {
-                                        "instance": {
-                                            "$ref": "/common-1.json#/definitions/crossref",
-                                            "$schemaRef": "/dependencies/jenkins-instance-1.yml"
-                                        },
-                                        "name": {
-                                            "description": "name of jenkins job to wait for",
-                                            "type": "string"
-                                        }
-                                    },
-                                    "required": [
-                                        "instance",
-                                        "name"
-                                    ]
-                                }
-                            },
-                            "required": [
-                                "tag_name",
-                                "url",
-                                "ref"
-                            ]
-                        },
-                        "output_resource_name": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "output_format": {
-                            "$ref": "/openshift/terraform-output-format-1.yml"
-                        },
-                        "annotations": {
-                            "$ref": "/common-1.json#/definitions/annotations"
-                        }
-                    },
-                    "required": [
-                        "account",
-                        "identifier",
-                        "defaults",
-                        "image"
-                    ]
-                },
-                {
-                    "additionalProperties": false,
-                    "properties": {
-                        "provider": {
-                            "type": "string",
-                            "enum": [
-                                "route53-zone"
-                            ]
-                        },
-                        "account": {
-                            "$ref": "/aws/tenant_accounts-1.yml#/properties/account"
-                        },
-                        "identifier": {
-                            "type": "string"
-                        },
-                        "name": {
-                            "description": "base fqdn of the zone",
-                            "$ref": "/common-1.json#/definitions/k8sValidContainerName"
-                        },
-                        "region": {
-                            "$ref": "/aws/regions-1.yml#/properties/region"
-                        },
-                        "output_resource_name": {
-                            "$ref": "/common-1.json#/definitions/longIdentifier"
-                        },
-                        "output_format": {
-                            "$ref": "/openshift/terraform-output-format-1.yml"
-                        },
-                        "annotations": {
-                            "$ref": "/common-1.json#/definitions/annotations"
-                        }
-                    },
-                    "required": [
-                        "account",
-                        "identifier",
-                        "name"
-                    ]
-                }
-            ],
-            "required": [
-                "provider"
             ]
         },
         "/vault-config/audit-1.yml": {
@@ -10179,6 +10871,9 @@
                                                 "oidc"
                                             ]
                                         },
+                                        "default_role": {
+                                            "type": "string"
+                                        },
                                         "oidc_discovery_url": {
                                             "type": "string"
                                         },
@@ -10186,17 +10881,22 @@
                                             "type": "string"
                                         },
                                         "oidc_client_secret": {
-                                            "type": "string"
+                                            "$ref": "/common-1.json#/definitions/vaultSecret"
                                         },
-                                        "default_role": {
-                                            "type": "string"
+                                        "oidc_client_secret_kv_version": {
+                                            "type": "string",
+                                            "enum": [
+                                                "kv_v1",
+                                                "kv_v2"
+                                            ]
                                         }
                                     },
                                     "required": [
+                                        "default_role",
                                         "oidc_discovery_url",
                                         "oidc_client_id",
                                         "oidc_client_secret",
-                                        "default_role"
+                                        "oidc_client_secret_kv_version"
                                     ]
                                 }
                             ]
@@ -10785,6 +11485,10 @@
                     "type": "string",
                     "pattern": "^[A-Za-z0-9][A-Za-z0-9-_]{0,30}[A-Za-z0-9]$"
                 },
+                "resourceref": {
+                    "type": "string",
+                    "pattern": "^/(?:[^/]+/)*[^/]+$"
+                },
                 "extendedIdentifier": {
                     "type": "string",
                     "pattern": "^[A-Za-z0-9][A-Za-z0-9-_\\.]{0,30}[A-Za-z0-9]$"
@@ -10792,6 +11496,10 @@
                 "longIdentifier": {
                     "type": "string",
                     "pattern": "^[a-z0-9][a-z0-9-]{3,63}[a-z0-9]$"
+                },
+                "botIdentifier": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z0-9][A-Za-z0-9-_]{0,30}[A-Za-z0-9](\\[bot\\])?$"
                 },
                 "nonEmptyString": {
                     "type": "string",
@@ -10981,9183 +11689,9776 @@
             ]
         }
     },
-    "graphql": [
-        {
-            "name": "AppInterfaceSettings_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "vault",
-                    "type": "boolean",
-                    "isRequired": true
-                },
-                {
-                    "name": "kubeBinary",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "pullRequestGateway",
-                    "type": "string"
-                },
-                {
-                    "name": "mergeRequestGateway",
-                    "type": "string"
-                },
-                {
-                    "name": "saasDeployJobTemplate",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "hashLength",
-                    "type": "int",
-                    "isRequired": true
-                },
-                {
-                    "name": "smtp",
-                    "type": "SmtpSettings_v1"
-                },
-                {
-                    "name": "githubRepoInvites",
-                    "type": "GithubRepoInvites_v1"
-                },
-                {
-                    "name": "dependencies",
-                    "type": "AppInterfaceDependencyMapping_v1",
-                    "isList": true
-                },
-                {
-                    "name": "credentials",
-                    "type": "CredentialsRequestMap_v1",
-                    "isList": true
-                },
-                {
-                    "name": "sqlQuery",
-                    "type": "SqlQuerySettings_v1"
-                },
-                {
-                    "name": "pushGatewayCluster",
-                    "type": "Cluster_v1"
-                },
-                {
-                    "name": "alertingServices",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "endpointMonitoringBlackboxExporterModules",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "ldap",
-                    "type": "LdapSettings_v1",
-                    "isRequired": false
-                }
-            ]
-        },
-        {
-            "name": "SmtpSettings_v1",
-            "fields": [
-                {
-                    "name": "mailAddress",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "credentials",
-                    "type": "VaultSecret_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "GithubRepoInvites_v1",
-            "fields": [
-                {
-                    "name": "credentials",
-                    "type": "VaultSecret_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "LdapSettings_v1",
-            "fields": [
-                {
-                    "name": "serverUrl",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "baseDn",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "AppInterfaceDependencyMapping_v1",
-            "fields": [
-                {
-                    "name": "type",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "services",
-                    "type": "Dependency_v1",
-                    "isRequired": true,
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "CredentialsRequestMap_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "secret",
-                    "type": "VaultSecret_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "CredentialsRequest_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "user",
-                    "type": "User_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "credentials",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "SqlQuerySettings_v1",
-            "fields": [
-                {
-                    "name": "imageRepository",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "pullSecret",
-                    "type": "NamespaceOpenshiftResourceVaultSecret_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "AppInterfaceEmail_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "subject",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "to",
-                    "type": "AppInterfaceEmailAudience_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "body",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "AppInterfaceEmailAudience_v1",
-            "fields": [
-                {
-                    "name": "aliases",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "services",
-                    "type": "App_v1",
-                    "isList": true
-                },
-                {
-                    "name": "clusters",
-                    "type": "Cluster_v1",
-                    "isList": true
-                },
-                {
-                    "name": "namespaces",
-                    "type": "Namespace_v1",
-                    "isList": true
-                },
-                {
-                    "name": "aws_accounts",
-                    "type": "AWSAccount_v1",
-                    "isList": true
-                },
-                {
-                    "name": "roles",
-                    "type": "Role_v1",
-                    "isList": true
-                },
-                {
-                    "name": "users",
-                    "type": "User_v1",
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "AppInterfaceSlackNotification_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "subject",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "channel",
-                    "type": "string"
-                },
-                {
-                    "name": "to",
-                    "type": "AppInterfaceSlackNotificationAudience_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "body",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "AppInterfaceSlackNotificationAudience_v1",
-            "fields": [
-                {
-                    "name": "users",
-                    "type": "string",
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "VaultAuditOptions_v1",
-            "isInterface": true,
-            "interfaceResolve": {
-                "strategy": "fieldMap",
-                "field": "_type",
-                "fieldMap": {
-                    "file": "VaultAuditOptionsFile_v1"
-                }
+    "graphql": {
+        "$schema": "/app-interface/graphql-schemas-1.yml",
+        "confs": [
+            {
+                "name": "AppInterfaceSettings_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "repoUrl",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "vault",
+                        "type": "boolean",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "kubeBinary",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "pullRequestGateway",
+                        "type": "string"
+                    },
+                    {
+                        "name": "mergeRequestGateway",
+                        "type": "string"
+                    },
+                    {
+                        "name": "saasDeployJobTemplate",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "hashLength",
+                        "type": "int",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "smtp",
+                        "type": "SmtpSettings_v1"
+                    },
+                    {
+                        "name": "imap",
+                        "type": "ImapSettings_v1"
+                    },
+                    {
+                        "name": "githubRepoInvites",
+                        "type": "GithubRepoInvites_v1"
+                    },
+                    {
+                        "name": "dependencies",
+                        "type": "AppInterfaceDependencyMapping_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "credentials",
+                        "type": "CredentialsRequestMap_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "sqlQuery",
+                        "type": "SqlQuerySettings_v1"
+                    },
+                    {
+                        "name": "pushGatewayCluster",
+                        "type": "Cluster_v1"
+                    },
+                    {
+                        "name": "alertingServices",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "endpointMonitoringBlackboxExporterModules",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "ldap",
+                        "type": "LdapSettings_v1",
+                        "isRequired": false
+                    }
+                ]
             },
-            "fields": [
-                {
-                    "name": "_type",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "VaultAuditOptionsFile_v1",
-            "interface": "VaultAuditOptions_v1",
-            "fields": [
-                {
-                    "name": "_type",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "file_path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "log_raw",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "hmac_accessor",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "mode",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "format",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "prefix",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "VaultAudit_v1",
-            "fields": [
-                {
-                    "name": "_path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "type",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "instance",
-                    "type": "VaultInstance_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "options",
-                    "type": "VaultAuditOptions_v1",
-                    "isInterface": true,
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "VaultAuthConfig_v1",
-            "isInterface": true,
-            "interfaceResolve": {
-                "strategy": "fieldMap",
-                "field": "_type",
-                "fieldMap": {
-                    "github": "VaultAuthConfigGithub_v1",
-                    "oidc": "VaultAuthConfigOidc_v1"
-                }
+            {
+                "name": "SmtpSettings_v1",
+                "fields": [
+                    {
+                        "name": "mailAddress",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "timeout",
+                        "type": "int"
+                    },
+                    {
+                        "name": "credentials",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
+                    }
+                ]
             },
-            "fields": [
-                {
-                    "name": "_type",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "VaultAuthConfigGithub_v1",
-            "interface": "VaultAuthConfig_v1",
-            "fields": [
-                {
-                    "name": "_type",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "organization",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "base_url",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "max_ttl",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "ttl",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "VaultAuthConfigOidc_v1",
-            "interface": "VaultAuthConfig_v1",
-            "fields": [
-                {
-                    "name": "_type",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "oidc_discovery_url",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "oidc_client_id",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "oidc_client_secret",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "default_role",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "VaultAuthSettings_v1",
-            "fields": [
-                {
-                    "name": "config",
-                    "type": "VaultAuthConfig_v1",
-                    "isInterface": true,
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "VaultSecretEngineOptions_v1",
-            "isInterface": true,
-            "interfaceResolve": {
-                "strategy": "fieldMap",
-                "field": "_type",
-                "fieldMap": {
-                    "kv": "VaultSecretEngineOptionsKV_v1"
-                }
+            {
+                "name": "ImapSettings_v1",
+                "fields": [
+                    {
+                        "name": "timeout",
+                        "type": "int"
+                    },
+                    {
+                        "name": "credentials",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
+                    }
+                ]
             },
-            "fields": [
-                {
-                    "name": "_type",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "VaultSecretEngineOptionsKV_v1",
-            "interface": "VaultSecretEngineOptions_v1",
-            "fields": [
-                {
-                    "name": "_type",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "version",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "VaultSecretEngine_v1",
-            "fields": [
-                {
-                    "name": "_path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "type",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "instance",
-                    "type": "VaultInstance_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "options",
-                    "type": "VaultSecretEngineOptions_v1",
-                    "isInterface": true
-                }
-            ]
-        },
-        {
-            "name": "VaultRoleOptions_v1",
-            "isInterface": true,
-            "interfaceResolve": {
-                "strategy": "fieldMap",
-                "field": "_type",
-                "fieldMap": {
-                    "approle": "VaultApproleOptions_v1",
-                    "oidc": "VaultRoleOidcOptions_v1"
-                }
+            {
+                "name": "GithubRepoInvites_v1",
+                "fields": [
+                    {
+                        "name": "credentials",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
+                    }
+                ]
             },
-            "fields": [
-                {
-                    "name": "_type",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "VaultApproleOptions_v1",
-            "interface": "VaultRoleOptions_v1",
-            "fields": [
-                {
-                    "name": "_type",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "bind_secret_id",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "local_secret_ids",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "token_period",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "secret_id_num_uses",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "secret_id_ttl",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "token_explicit_max_ttl",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "token_max_ttl",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "token_no_default_policy",
-                    "type": "boolean",
-                    "isRequired": true
-                },
-                {
-                    "name": "token_num_uses",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "token_ttl",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "token_type",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "token_policies",
-                    "type": "string",
-                    "isList": true,
-                    "isRequired": true
-                },
-                {
-                    "name": "policies",
-                    "type": "string",
-                    "isList": true,
-                    "isRequired": true
-                },
-                {
-                    "name": "secret_id_bound_cidrs",
-                    "type": "string",
-                    "isList": true,
-                    "isRequired": true
-                },
-                {
-                    "name": "token_bound_cidrs",
-                    "type": "string",
-                    "isList": true,
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "VaultRoleOidcOptions_v1",
-            "interface": "VaultRoleOptions_v1",
-            "fields": [
-                {
-                    "name": "_type",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "allowed_redirect_uris",
-                    "type": "string",
-                    "isList": true,
-                    "isRequired": true
-                },
-                {
-                    "name": "bound_audiences",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "bound_claims",
-                    "type": "json"
-                },
-                {
-                    "name": "bound_claims_type",
-                    "type": "string"
-                },
-                {
-                    "name": "bound_subject",
-                    "type": "string"
-                },
-                {
-                    "name": "claim_mappings",
-                    "type": "json"
-                },
-                {
-                    "name": "clock_skew_leeway",
-                    "type": "string"
-                },
-                {
-                    "name": "expiration_leeway",
-                    "type": "string"
-                },
-                {
-                    "name": "groups_claim",
-                    "type": "string"
-                },
-                {
-                    "name": "max_age",
-                    "type": "string"
-                },
-                {
-                    "name": "not_before_leeway",
-                    "type": "string"
-                },
-                {
-                    "name": "oidc_scopes",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "role_type",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "token_ttl",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "token_max_ttl",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "token_explicit_max_ttl",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "token_type",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "token_period",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "token_policies",
-                    "type": "string",
-                    "isList": true,
-                    "isRequired": true
-                },
-                {
-                    "name": "token_bound_cidrs",
-                    "type": "string",
-                    "isList": true,
-                    "isRequired": true
-                },
-                {
-                    "name": "token_no_default_policy",
-                    "type": "boolean",
-                    "isRequired": true
-                },
-                {
-                    "name": "token_num_uses",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "user_claim",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "verbose_oidc_logging",
-                    "type": "boolean"
-                }
-            ]
-        },
-        {
-            "name": "VaultRole_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "type",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "mount",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "instance",
-                    "type": "VaultInstance_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "options",
-                    "type": "VaultRoleOptions_v1",
-                    "isInterface": true,
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "VaultPolicy_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "instance",
-                    "type": "VaultInstance_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "rules",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "Resource_v1",
-            "fields": [
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "content",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "sha256sum",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "schema",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "VaultSecret_v1",
-            "fields": [
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "field",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "format",
-                    "type": "string"
-                },
-                {
-                    "name": "version",
-                    "type": "int"
-                }
-            ]
-        },
-        {
-            "name": "KeyValue_v1",
-            "fields": [
-                {
-                    "name": "key",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "value",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "ClusterJumpHost_v1",
-            "fields": [
-                {
-                    "name": "hostname",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "knownHosts",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "user",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "port",
-                    "type": "int"
-                },
-                {
-                    "name": "identity",
-                    "type": "VaultSecret_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "DisableClusterAutomations_v1",
-            "fields": [
-                {
-                    "name": "integrations",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "e2eTests",
-                    "type": "string",
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "GcpProject_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "managedTeams",
-                    "type": "string",
-                    "isList": true,
-                    "isRequired": true
-                },
-                {
-                    "name": "automationToken",
-                    "type": "VaultSecret_v1"
-                },
-                {
-                    "name": "pushCredentials",
-                    "type": "VaultSecret_v1"
-                }
-            ]
-        },
-        {
-            "name": "GrafanaDashboardUrls_v1",
-            "fields": [
-                {
-                    "name": "title",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "url",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "QuayOrg_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "mirror",
-                    "type": "QuayOrg_v1"
-                },
-                {
-                    "name": "managedRepos",
-                    "type": "boolean",
-                    "isRequired": true
-                },
-                {
-                    "name": "instance",
-                    "type": "QuayInstance_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "serverUrl",
-                    "type": "string"
-                },
-                {
-                    "name": "managedTeams",
-                    "type": "string",
-                    "isList": true,
-                    "isRequired": true
-                },
-                {
-                    "name": "automationToken",
-                    "type": "VaultSecret_v1"
-                },
-                {
-                    "name": "pushCredentials",
-                    "type": "VaultSecret_v1"
-                }
-            ]
-        },
-        {
-            "name": "QuayInstance_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "url",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "JenkinsInstanceBuildsCleanupRules_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "keep_hours",
-                    "type": "int",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "JenkinsInstance_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "serverUrl",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "token",
-                    "type": "VaultSecret_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "previousUrls",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "plugins",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "deleteMethod",
-                    "type": "string"
-                },
-                {
-                    "name": "managedProjects",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "buildsCleanupRules",
-                    "type": "JenkinsInstanceBuildsCleanupRules_v1",
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "JenkinsConfig_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "app",
-                    "type": "App_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "instance",
-                    "type": "JenkinsInstance_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "type",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "config",
-                    "type": "json"
-                },
-                {
-                    "name": "config_path",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "JiraServer_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "serverUrl",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "token",
-                    "type": "VaultSecret_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "SeverityPriorityMapping_v1",
-            "fields": [
-                {
-                    "name": "severity",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "priority",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "JiraSeverityPriorityMappings_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "mappings",
-                    "type": "SeverityPriorityMapping_v1",
-                    "isList": true,
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "JiraBoard_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true,
-                    "isUnique": true,
-                    "isSearchable": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "server",
-                    "type": "JiraServer_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "severityPriorityMappings",
-                    "type": "JiraSeverityPriorityMappings_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "slack",
-                    "type": "SlackOutput_v1"
-                }
-            ]
-        },
-        {
-            "name": "SendGridAccount_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true,
-                    "isUnique": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "token",
-                    "type": "VaultSecret_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "SlackWorkspace_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "token",
-                    "type": "VaultSecret_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "api_client",
-                    "type": "SlackWorkspaceApiClient_v1"
-                },
-                {
-                    "name": "integrations",
-                    "type": "SlackWorkspaceIntegration_v1",
-                    "isList": true
-                },
-                {
-                    "name": "managedUsergroups",
-                    "type": "string",
-                    "isList": true,
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "SlackWorkspaceApiClient_v1",
-            "fields": [
-                {
-                    "name": "global",
-                    "type": "SlackWorkspaceApiClientGlobalConfig_v1"
-                },
-                {
-                    "name": "methods",
-                    "type": "SlackWorkspaceApiClientMethodConfig_v1",
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "SlackWorkspaceApiClientGlobalConfig_v1",
-            "fields": [
-                {
-                    "name": "max_retries",
-                    "type": "int"
-                },
-                {
-                    "name": "timeout",
-                    "type": "int"
-                }
-            ]
-        },
-        {
-            "name": "SlackWorkspaceApiClientMethodConfig_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "args",
-                    "type": "json",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "SlackWorkspaceIntegration_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "token",
-                    "type": "VaultSecret_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "channel",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "icon_emoji",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "username",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "GithubOrg_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "url",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "two_factor_authentication",
-                    "type": "boolean",
-                    "isRequired": true
-                },
-                {
-                    "name": "default",
-                    "type": "boolean"
-                },
-                {
-                    "name": "token",
-                    "type": "VaultSecret_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "managedTeams",
-                    "type": "string",
-                    "isList": true,
-                    "isRequired": false
-                }
-            ]
-        },
-        {
-            "name": "GitlabProjects_v1",
-            "fields": [
-                {
-                    "name": "group",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "projects",
-                    "type": "string",
-                    "isList": true,
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "GitlabInstance_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "backupOrgs",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "managedGroups",
-                    "type": "string",
-                    "isList": true,
-                    "isRequired": true
-                },
-                {
-                    "name": "projectRequests",
-                    "type": "GitlabProjects_v1",
-                    "isList": true
-                },
-                {
-                    "name": "url",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "token",
-                    "type": "VaultSecret_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "sslVerify",
-                    "type": "boolean"
-                }
-            ]
-        },
-        {
-            "name": "PagerDutyInstance_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "token",
-                    "type": "VaultSecret_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "PagerDutyTarget_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "instance",
-                    "type": "PagerDutyInstance_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "scheduleID",
-                    "type": "string"
-                },
-                {
-                    "name": "escalationPolicyID",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "ClusterAuth_v1",
-            "isInterface": true,
-            "interfaceResolve": {
-                "strategy": "fieldMap",
-                "field": "service",
-                "fieldMap": {
-                    "github-org": "ClusterAuthGithubOrg_v1",
-                    "github-org-team": "ClusterAuthGithubOrgTeam_v1",
-                    "oidc": "ClusterAuthOIDC_v1"
-                }
+            {
+                "name": "LdapSettings_v1",
+                "fields": [
+                    {
+                        "name": "serverUrl",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "baseDn",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
             },
-            "fields": [
-                {
-                    "name": "service",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "ClusterAuthGithubOrg_v1",
-            "interface": "ClusterAuth_v1",
-            "fields": [
-                {
-                    "name": "service",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "org",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "ClusterAuthGithubOrgTeam_v1",
-            "interface": "ClusterAuth_v1",
-            "fields": [
-                {
-                    "name": "service",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "org",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "team",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "ClusterAuthOIDC_v1",
-            "interface": "ClusterAuth_v1",
-            "fields": [
-                {
-                    "name": "service",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "KafkaClusterSpec_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "region",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "multi_az",
-                    "type": "boolean",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "ClusterSpec_v1",
-            "fields": [
-                {
-                    "name": "id",
-                    "type": "string"
-                },
-                {
-                    "name": "external_id",
-                    "type": "string"
-                },
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "region",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "channel",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "version",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "initial_version",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "multi_az",
-                    "type": "boolean",
-                    "isRequired": true
-                },
-                {
-                    "name": "nodes",
-                    "type": "int"
-                },
-                {
-                    "name": "instance_type",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "storage",
-                    "type": "int",
-                    "isRequired": true
-                },
-                {
-                    "name": "load_balancers",
-                    "type": "int",
-                    "isRequired": true
-                },
-                {
-                    "name": "private",
-                    "type": "boolean",
-                    "isRequired": true
-                },
-                {
-                    "name": "provision_shard_id",
-                    "type": "string"
-                },
-                {
-                    "name": "autoscale",
-                    "type": "ClusterSpecAutoScale_v1"
-                },
-                {
-                    "name": "disable_user_workload_monitoring",
-                    "type": "boolean"
-                }
-            ]
-        },
-        {
-            "name": "ClusterSpecAutoScale_v1",
-            "fields": [
-                {
-                    "name": "min_replicas",
-                    "type": "int",
-                    "isRequired": true
-                },
-                {
-                    "name": "max_replicas",
-                    "type": "int",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "ClusterExternalConfiguration_v1",
-            "fields": [
-                {
-                    "name": "labels",
-                    "type": "json",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "ClusterAdditionalRouter_v1",
-            "fields": [
-                {
-                    "name": "private",
-                    "type": "boolean",
-                    "isRequired": true
-                },
-                {
-                    "name": "route_selectors",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "ClusterUpgradePolicyConditions_v1",
-            "fields": [
-                {
-                    "name": "soakDays",
-                    "type": "int"
-                },
-                {
-                    "name": "mutexes",
-                    "type": "string",
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "ClusterUpgradePolicy_v1",
-            "fields": [
-                {
-                    "name": "schedule_type",
-                    "type": "string"
-                },
-                {
-                    "name": "schedule",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "workloads",
-                    "type": "string",
-                    "isList": true,
-                    "isRequired": true
-                },
-                {
-                    "name": "conditions",
-                    "type": "ClusterUpgradePolicyConditions_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "ClusterNetwork_v1",
-            "fields": [
-                {
-                    "name": "type",
-                    "type": "string"
-                },
-                {
-                    "name": "vpc",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "service",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "pod",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "ClusterMachinePool_v1",
-            "fields": [
-                {
-                    "name": "id",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "instance_type",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "replicas",
-                    "type": "int",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "taints",
-                    "type": "Taint_v1",
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "Taint_v1",
-            "fields": [
-                {
-                    "name": "key",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "value",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "effect",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "ClusterPeeringConnection_v1",
-            "isInterface": true,
-            "interfaceResolve": {
-                "strategy": "fieldMap",
-                "field": "provider",
-                "fieldMap": {
-                    "account-vpc": "ClusterPeeringConnectionAccount_v1",
-                    "account-vpc-mesh": "ClusterPeeringConnectionAccountVPCMesh_v1",
-                    "account-tgw": "ClusterPeeringConnectionAccountTGW_v1",
-                    "cluster-vpc-requester": "ClusterPeeringConnectionClusterRequester_v1",
-                    "cluster-vpc-accepter": "ClusterPeeringConnectionClusterAccepter_v1"
-                }
+            {
+                "name": "AppInterfaceDependencyMapping_v1",
+                "fields": [
+                    {
+                        "name": "type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "services",
+                        "type": "Dependency_v1",
+                        "isRequired": true,
+                        "isList": true
+                    }
+                ]
             },
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string"
-                },
-                {
-                    "name": "manageRoutes",
-                    "type": "boolean"
-                },
-                {
-                    "name": "delete",
-                    "type": "boolean"
-                }
-            ]
-        },
-        {
-            "name": "ClusterPeeringConnectionAccount_v1",
-            "interface": "ClusterPeeringConnection_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "vpc",
-                    "type": "AWSVPC_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string"
-                },
-                {
-                    "name": "manageRoutes",
-                    "type": "boolean"
-                },
-                {
-                    "name": "delete",
-                    "type": "boolean"
-                },
-                {
-                    "name": "assumeRole",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "ClusterPeeringConnectionAccountVPCMesh_v1",
-            "interface": "ClusterPeeringConnection_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "AWSAccount_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string"
-                },
-                {
-                    "name": "tags",
-                    "type": "json"
-                },
-                {
-                    "name": "manageRoutes",
-                    "type": "boolean"
-                },
-                {
-                    "name": "delete",
-                    "type": "boolean"
-                }
-            ]
-        },
-        {
-            "name": "ClusterPeeringConnectionAccountTGW_v1",
-            "interface": "ClusterPeeringConnection_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "AWSAccount_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string"
-                },
-                {
-                    "name": "tags",
-                    "type": "json"
-                },
-                {
-                    "name": "manageRoutes",
-                    "type": "boolean"
-                },
-                {
-                    "name": "manageSecurityGroups",
-                    "type": "boolean"
-                },
-                {
-                    "name": "cidrBlock",
-                    "type": "string"
-                },
-                {
-                    "name": "delete",
-                    "type": "boolean"
-                },
-                {
-                    "name": "assumeRole",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "ClusterPeeringConnectionClusterRequester_v1",
-            "interface": "ClusterPeeringConnection_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "cluster",
-                    "type": "Cluster_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string"
-                },
-                {
-                    "name": "manageRoutes",
-                    "type": "boolean"
-                },
-                {
-                    "name": "delete",
-                    "type": "boolean"
-                },
-                {
-                    "name": "assumeRole",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "ClusterPeeringConnectionClusterAccepter_v1",
-            "interface": "ClusterPeeringConnection_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "cluster",
-                    "type": "Cluster_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "awsInfrastructureManagementAccount",
-                    "type": "AWSAccount_v1"
-                },
-                {
-                    "name": "description",
-                    "type": "string"
-                },
-                {
-                    "name": "manageRoutes",
-                    "type": "boolean"
-                },
-                {
-                    "name": "delete",
-                    "type": "boolean"
-                },
-                {
-                    "name": "assumeRole",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "ClusterPeering_v1",
-            "fields": [
-                {
-                    "name": "connections",
-                    "type": "ClusterPeeringConnection_v1",
-                    "isRequired": true,
-                    "isList": true,
-                    "isInterface": true
-                }
-            ]
-        },
-        {
-            "name": "ClusterPrometheus_v1",
-            "fields": [
-                {
-                    "name": "url",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "auth",
-                    "type": "VaultSecret_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "Cluster_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isUnique": true,
-                    "isSearchable": true,
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string"
-                },
-                {
-                    "name": "auth",
-                    "type": "ClusterAuth_v1",
-                    "isInterface": true
-                },
-                {
-                    "name": "observabilityNamespace",
-                    "type": "Namespace_v1"
-                },
-                {
-                    "name": "grafanaUrl",
-                    "type": "string"
-                },
-                {
-                    "name": "consoleUrl",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "kibanaUrl",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "prometheusUrl",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "alertmanagerUrl",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "serverUrl",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "elbFQDN",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "managedGroups",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "managedClusterRoles",
-                    "type": "boolean"
-                },
-                {
-                    "name": "ocm",
-                    "type": "OpenShiftClusterManager_v1"
-                },
-                {
-                    "name": "spec",
-                    "type": "ClusterSpec_v1"
-                },
-                {
-                    "name": "externalConfiguration",
-                    "type": "ClusterExternalConfiguration_v1"
-                },
-                {
-                    "name": "upgradePolicy",
-                    "type": "ClusterUpgradePolicy_v1"
-                },
-                {
-                    "name": "additionalRouters",
-                    "type": "ClusterAdditionalRouter_v1",
-                    "isList": true
-                },
-                {
-                    "name": "network",
-                    "type": "ClusterNetwork_v1"
-                },
-                {
-                    "name": "machinePools",
-                    "type": "ClusterMachinePool_v1",
-                    "isList": true
-                },
-                {
-                    "name": "peering",
-                    "type": "ClusterPeering_v1"
-                },
-                {
-                    "name": "addons",
-                    "type": "ClusterAddon_v1",
-                    "isList": true
-                },
-                {
-                    "name": "insecureSkipTLSVerify",
-                    "type": "boolean"
-                },
-                {
-                    "name": "jumpHost",
-                    "type": "ClusterJumpHost_v1"
-                },
-                {
-                    "name": "automationToken",
-                    "type": "VaultSecret_v1"
-                },
-                {
-                    "name": "clusterAdminAutomationToken",
-                    "type": "VaultSecret_v1"
-                },
-                {
-                    "name": "internal",
-                    "type": "boolean"
-                },
-                {
-                    "name": "disable",
-                    "type": "DisableClusterAutomations_v1"
-                },
-                {
-                    "name": "awsInfrastructureAccess",
-                    "type": "AWSInfrastructureAccess_v1",
-                    "isList": true
-                },
-                {
-                    "name": "awsInfrastructureManagementAccounts",
-                    "type": "AWSInfrastructureManagementAccount_v1",
-                    "isList": true
-                },
-                {
-                    "name": "prometheus",
-                    "type": "ClusterPrometheus_v1"
-                },
-                {
-                    "name": "namespaces",
-                    "type": "Namespace_v1",
-                    "isList": true,
-                    "synthetic": {
-                        "schema": "/openshift/namespace-1.yml",
-                        "subAttr": "cluster"
+            {
+                "name": "CredentialsRequestMap_v1",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "secret",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
                     }
-                }
-            ]
-        },
-        {
-            "name": "KafkaCluster_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string"
-                },
-                {
-                    "name": "ocm",
-                    "type": "OpenShiftClusterManager_v1"
-                },
-                {
-                    "name": "spec",
-                    "type": "KafkaClusterSpec_v1"
-                },
-                {
-                    "name": "namespaces",
-                    "type": "Namespace_v1",
-                    "isList": true,
-                    "synthetic": {
-                        "schema": "/openshift/namespace-1.yml",
-                        "subAttr": "kafkaCluster"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "OpenShiftClusterManager_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string"
-                },
-                {
-                    "name": "url",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "accessTokenClientId",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "accessTokenUrl",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "offlineToken",
-                    "type": "VaultSecret_v1"
-                },
-                {
-                    "name": "blockedVersions",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "clusters",
-                    "type": "Cluster_v1",
-                    "isList": true,
-                    "synthetic": {
-                        "schema": "/openshift/cluster-1.yml",
-                        "subAttr": "cluster"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "ClusterAddon_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string"
-                },
-                {
-                    "name": "parameters",
-                    "type": "ClusterAddonParameters_v1",
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "ClusterAddonParameters_v1",
-            "fields": [
-                {
-                    "name": "id",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "value",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "AWSInfrastructureAccess_v1",
-            "fields": [
-                {
-                    "name": "awsGroup",
-                    "type": "AWSGroup_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "accessLevel",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "AWSInfrastructureManagementAccount_v1",
-            "fields": [
-                {
-                    "name": "account",
-                    "type": "AWSAccount_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "accessLevel",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "default",
-                    "type": "boolean"
-                }
-            ]
-        },
-        {
-            "name": "AWSAccount_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true,
-                    "isUnique": true,
-                    "isSearchable": true
-                },
-                {
-                    "name": "description",
-                    "type": "string"
-                },
-                {
-                    "name": "consoleUrl",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "uid",
-                    "type": "string",
-                    "isRequired": true,
-                    "isSearchable": true
-                },
-                {
-                    "name": "resourcesDefaultRegion",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "supportedDeploymentRegions",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "providerVersion",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "terraformUsername",
-                    "type": "string"
-                },
-                {
-                    "name": "accountOwners",
-                    "type": "Owner_v1",
-                    "isList": true,
-                    "isRequired": true
-                },
-                {
-                    "name": "automationToken",
-                    "type": "VaultSecret_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "garbageCollection",
-                    "type": "boolean"
-                },
-                {
-                    "name": "enableDeletion",
-                    "type": "boolean"
-                },
-                {
-                    "name": "deletionApprovals",
-                    "type": "AWSAccountDeletionApproval_v1",
-                    "isList": true
-                },
-                {
-                    "name": "disable",
-                    "type": "DisableClusterAutomations_v1"
-                },
-                {
-                    "name": "deleteKeys",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "resetPasswords",
-                    "type": "AWSAccountResetPassword_v1",
-                    "isList": true
-                },
-                {
-                    "name": "premiumSupport",
-                    "type": "boolean",
-                    "isRequired": true
-                },
-                {
-                    "name": "partition",
-                    "type": "string"
-                },
-                {
-                    "name": "sharing",
-                    "type": "AWSAccountSharingOption_v1",
-                    "isList": true,
-                    "isInterface": true
-                },
-                {
-                    "name": "ecrs",
-                    "type": "AWSECR_v1",
-                    "isList": true,
-                    "synthetic": {
-                        "schema": "/aws/ecr-1.yml",
-                        "subAttr": "account"
-                    }
-                },
-                {
-                    "name": "policies",
-                    "type": "AWSUserPolicy_v1",
-                    "isList": true,
-                    "synthetic": {
-                        "schema": "/aws/policy-1.yml",
-                        "subAttr": "account"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "AWSGroup_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "account",
-                    "type": "AWSAccount_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string"
-                },
-                {
-                    "name": "policies",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "roles",
-                    "type": "Role_v1",
-                    "isList": true,
-                    "synthetic": {
-                        "schema": "/access/role-1.yml",
-                        "subAttr": "aws_groups"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "AWSAccountDeletionApproval_v1",
-            "fields": [
-                {
-                    "name": "type",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "expiration",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "AWSAccountResetPassword_v1",
-            "fields": [
-                {
-                    "name": "user",
-                    "type": "User_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "requestId",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "AWSAccountSharingOption_v1",
-            "isInterface": true,
-            "interfaceResolve": {
-                "strategy": "fieldMap",
-                "field": "provider",
-                "fieldMap": {
-                    "ami": "AWSAccountSharingOptionAMI_v1"
-                }
+                ]
             },
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "AWSAccount_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "AWSAccountSharingOptionAMI_v1",
-            "interface": "AWSAccountSharingOption_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "AWSAccount_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "regex",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "region",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "AWSUserPolicy_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "account",
-                    "type": "AWSAccount_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string"
-                },
-                {
-                    "name": "mandatory",
-                    "type": "boolean"
-                },
-                {
-                    "name": "policy",
-                    "type": "json",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "AWSVPC_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "account",
-                    "type": "AWSAccount_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string"
-                },
-                {
-                    "name": "vpc_id",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "cidr_block",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "region",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "subnets",
-                    "type": "AWSSubnet_v1",
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "AWSSubnet_v1",
-            "fields": [
-                {
-                    "name": "id",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "AWSECR_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "account",
-                    "type": "AWSAccount_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string"
-                },
-                {
-                    "name": "region",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "AWSS3EventNotification_v1",
-            "fields": [
-                {
-                    "name": "event_type",
-                    "type": "string",
-                    "isRequired": true,
-                    "isList": true
-                },
-                {
-                    "name": "destination",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "destination_type",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "filter_prefix",
-                    "type": "string"
-                },
-                {
-                    "name": "filter_suffix",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "ACMDomain_v1",
-            "fields": [
-                {
-                    "name": "domain_name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "alternate_names",
-                    "type": "string",
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "NamespaceOpenshiftResource_v1",
-            "isInterface": true,
-            "interfaceResolve": {
-                "strategy": "fieldMap",
-                "field": "provider",
-                "fieldMap": {
-                    "resource": "NamespaceOpenshiftResourceResource_v1",
-                    "resource-template": "NamespaceOpenshiftResourceResourceTemplate_v1",
-                    "vault-secret": "NamespaceOpenshiftResourceVaultSecret_v1",
-                    "route": "NamespaceOpenshiftResourceRoute_v1"
-                }
+            {
+                "name": "CredentialsRequest_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "user",
+                        "type": "User_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "credentials",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
             },
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "NamespaceOpenshiftResourceResource_v1",
-            "interface": "NamespaceOpenshiftResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "validate_json",
-                    "type": "boolean"
-                },
-                {
-                    "name": "validate_alertmanager_config",
-                    "type": "boolean"
-                },
-                {
-                    "name": "alertmanager_config_key",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceOpenshiftResourceResourceTemplate_v1",
-            "interface": "NamespaceOpenshiftResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "type",
-                    "type": "string"
-                },
-                {
-                    "name": "variables",
-                    "type": "json"
-                },
-                {
-                    "name": "validate_alertmanager_config",
-                    "type": "boolean"
-                },
-                {
-                    "name": "alertmanager_config_key",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceOpenshiftResourceVaultSecret_v1",
-            "interface": "NamespaceOpenshiftResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "version",
-                    "type": "int",
-                    "isRequired": true
-                },
-                {
-                    "name": "name",
-                    "type": "string"
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "annotations",
-                    "type": "json"
-                },
-                {
-                    "name": "type",
-                    "type": "string"
-                },
-                {
-                    "name": "validate_alertmanager_config",
-                    "type": "boolean"
-                },
-                {
-                    "name": "alertmanager_config_key",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceOpenshiftResourceRoute_v1",
-            "interface": "NamespaceOpenshiftResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "vault_tls_secret_path",
-                    "type": "string"
-                },
-                {
-                    "name": "vault_tls_secret_version",
-                    "type": "int"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResource_v1",
-            "isInterface": true,
-            "interfaceResolve": {
-                "strategy": "fieldMap",
-                "field": "provider",
-                "fieldMap": {
-                    "rds": "NamespaceTerraformResourceRDS_v1",
-                    "s3": "NamespaceTerraformResourceS3_v1",
-                    "elasticache": "NamespaceTerraformResourceElastiCache_v1",
-                    "aws-iam-service-account": "NamespaceTerraformResourceServiceAccount_v1",
-                    "secrets-manager-service-account": "NamespaceTerraformResourceSecretsManagerServiceAccount_v1",
-                    "aws-iam-role": "NamespaceTerraformResourceRole_v1",
-                    "sqs": "NamespaceTerraformResourceSQS_v1",
-                    "dynamodb": "NamespaceTerraformResourceDynamoDB_v1",
-                    "ecr": "NamespaceTerraformResourceECR_v1",
-                    "s3-cloudfront": "NamespaceTerraformResourceS3CloudFront_v1",
-                    "s3-sqs": "NamespaceTerraformResourceS3SQS_v1",
-                    "cloudwatch": "NamespaceTerraformResourceCloudWatch_v1",
-                    "kms": "NamespaceTerraformResourceKMS_v1",
-                    "elasticsearch": "NamespaceTerraformResourceElasticSearch_v1",
-                    "acm": "NamespaceTerraformResourceACM_v1",
-                    "kinesis": "NamespaceTerraformResourceKinesis_v1",
-                    "s3-cloudfront-public-key": "NamespaceTerraformResourceS3CloudFrontPublicKey_v1",
-                    "alb": "NamespaceTerraformResourceALB_v1",
-                    "secrets-manager": "NamespaceTerraformResourceSecretsManager_v1",
-                    "asg": "NamespaceTerraformResourceASG_v1",
-                    "route53-zone": "NamespaceTerraformResourceRoute53Zone_v1"
-                }
+            {
+                "name": "SqlQuerySettings_v1",
+                "fields": [
+                    {
+                        "name": "imageRepository",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "pullSecret",
+                        "type": "NamespaceOpenshiftResourceVaultSecret_v1",
+                        "isRequired": true
+                    }
+                ]
             },
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "identifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "output_resource_name",
-                    "type": "string"
-                },
-                {
-                    "name": "output_format",
-                    "type": "NamespaceTerraformResourceOutputFormat_v1",
-                    "isInterface": true
-                },
-                {
-                    "name": "annotations",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceOutputFormat_v1",
-            "isInterface": true,
-            "interfaceResolve": {
-                "strategy": "fieldMap",
-                "field": "provider",
-                "fieldMap": {
-                    "generic-secret": "NamespaceTerraformResourceGenericSecretOutputFormat_v1"
-                }
+            {
+                "name": "AppInterfaceEmail_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "subject",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "to",
+                        "type": "AppInterfaceEmailAudience_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "body",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
             },
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceGenericSecretOutputFormat_v1",
-            "interface": "NamespaceTerraformResourceOutputFormat_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "data",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceASG_v1",
-            "interface": "NamespaceTerraformResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "region",
-                    "type": "string"
-                },
-                {
-                    "name": "identifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "defaults",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "cloudinit_configs",
-                    "type": "CloudinitConfig_v1",
-                    "isList": true
-                },
-                {
-                    "name": "variables",
-                    "type": "json"
-                },
-                {
-                    "name": "image",
-                    "type": "ASGImage_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "output_resource_name",
-                    "type": "string"
-                },
-                {
-                    "name": "output_format",
-                    "type": "NamespaceTerraformResourceOutputFormat_v1",
-                    "isInterface": true
-                },
-                {
-                    "name": "annotations",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "CloudinitConfig_v1",
-            "fields": [
-                {
-                    "name": "filename",
-                    "type": "string"
-                },
-                {
-                    "name": "content_type",
-                    "type": "string"
-                },
-                {
-                    "name": "content",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "ASGImage_v1",
-            "fields": [
-                {
-                    "name": "tag_name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "url",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "ref",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "upstream",
-                    "type": "SaasResourceTemplateTargetUpstream_v1"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceSecretsManager_v1",
-            "interface": "NamespaceTerraformResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "region",
-                    "type": "string"
-                },
-                {
-                    "name": "identifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "secret",
-                    "type": "VaultSecret_v1"
-                },
-                {
-                    "name": "output_resource_name",
-                    "type": "string"
-                },
-                {
-                    "name": "output_format",
-                    "type": "NamespaceTerraformResourceOutputFormat_v1",
-                    "isInterface": true
-                },
-                {
-                    "name": "annotations",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceS3CloudFrontPublicKey_v1",
-            "interface": "NamespaceTerraformResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "region",
-                    "type": "string"
-                },
-                {
-                    "name": "identifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "secret",
-                    "type": "VaultSecret_v1"
-                },
-                {
-                    "name": "output_resource_name",
-                    "type": "string"
-                },
-                {
-                    "name": "output_format",
-                    "type": "NamespaceTerraformResourceOutputFormat_v1",
-                    "isInterface": true
-                },
-                {
-                    "name": "annotations",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceACM_v1",
-            "interface": "NamespaceTerraformResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "region",
-                    "type": "string"
-                },
-                {
-                    "name": "identifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "secret",
-                    "type": "VaultSecret_v1"
-                },
-                {
-                    "name": "domain",
-                    "type": "ACMDomain_v1"
-                },
-                {
-                    "name": "output_resource_name",
-                    "type": "string"
-                },
-                {
-                    "name": "output_format",
-                    "type": "NamespaceTerraformResourceOutputFormat_v1",
-                    "isInterface": true
-                },
-                {
-                    "name": "annotations",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceElasticSearch_v1",
-            "interface": "NamespaceTerraformResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "region",
-                    "type": "string"
-                },
-                {
-                    "name": "identifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "defaults",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "output_resource_name",
-                    "type": "string"
-                },
-                {
-                    "name": "output_format",
-                    "type": "NamespaceTerraformResourceOutputFormat_v1",
-                    "isInterface": true
-                },
-                {
-                    "name": "annotations",
-                    "type": "json"
-                },
-                {
-                    "name": "publish_log_types",
-                    "type": "string",
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceRDS_v1",
-            "interface": "NamespaceTerraformResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "region",
-                    "type": "string"
-                },
-                {
-                    "name": "identifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "defaults",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "availability_zone",
-                    "type": "string"
-                },
-                {
-                    "name": "parameter_group",
-                    "type": "string"
-                },
-                {
-                    "name": "overrides",
-                    "type": "json"
-                },
-                {
-                    "name": "output_resource_name",
-                    "type": "string"
-                },
-                {
-                    "name": "output_format",
-                    "type": "NamespaceTerraformResourceOutputFormat_v1",
-                    "isInterface": true
-                },
-                {
-                    "name": "output_resource_db_name",
-                    "type": "string"
-                },
-                {
-                    "name": "reset_password",
-                    "type": "string"
-                },
-                {
-                    "name": "enhanced_monitoring",
-                    "type": "boolean"
-                },
-                {
-                    "name": "replica_source",
-                    "type": "string"
-                },
-                {
-                    "name": "ca_cert",
-                    "type": "VaultSecret_v1"
-                },
-                {
-                    "name": "annotations",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceS3_v1",
-            "interface": "NamespaceTerraformResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "region",
-                    "type": "string"
-                },
-                {
-                    "name": "identifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "defaults",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "overrides",
-                    "type": "json"
-                },
-                {
-                    "name": "event_notifications",
-                    "type": "AWSS3EventNotification_v1",
-                    "isList": true
-                },
-                {
-                    "name": "sqs_identifier",
-                    "type": "string"
-                },
-                {
-                    "name": "s3_events",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "bucket_policy",
-                    "type": "json"
-                },
-                {
-                    "name": "output_resource_name",
-                    "type": "string"
-                },
-                {
-                    "name": "output_format",
-                    "type": "NamespaceTerraformResourceOutputFormat_v1",
-                    "isInterface": true
-                },
-                {
-                    "name": "storage_class",
-                    "type": "string"
-                },
-                {
-                    "name": "annotations",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceServiceAccountAWSInfrastructureAccess_v1",
-            "fields": [
-                {
-                    "name": "cluster",
-                    "type": "Cluster_v1"
-                },
-                {
-                    "name": "access_level",
-                    "type": "string"
-                },
-                {
-                    "name": "assume_role",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceServiceAccount_v1",
-            "interface": "NamespaceTerraformResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "identifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "variables",
-                    "type": "json"
-                },
-                {
-                    "name": "policies",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "user_policy",
-                    "type": "json"
-                },
-                {
-                    "name": "output_resource_name",
-                    "type": "string"
-                },
-                {
-                    "name": "output_format",
-                    "type": "NamespaceTerraformResourceOutputFormat_v1",
-                    "isInterface": true
-                },
-                {
-                    "name": "aws_infrastructure_access",
-                    "type": "NamespaceTerraformResourceServiceAccountAWSInfrastructureAccess_v1"
-                },
-                {
-                    "name": "annotations",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "AssumeRole_v1",
-            "fields": [
-                {
-                    "name": "AWS",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "Service",
-                    "type": "string",
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceSecretsManagerServiceAccount_v1",
-            "interface": "NamespaceTerraformResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "identifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "secrets_prefix",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "output_resource_name",
-                    "type": "string"
-                },
-                {
-                    "name": "output_format",
-                    "type": "NamespaceTerraformResourceOutputFormat_v1",
-                    "isInterface": true
-                },
-                {
-                    "name": "annotations",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceRole_v1",
-            "interface": "NamespaceTerraformResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "identifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "assume_role",
-                    "type": "AssumeRole_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "assume_condition",
-                    "type": "json"
-                },
-                {
-                    "name": "inline_policy",
-                    "type": "json"
-                },
-                {
-                    "name": "output_resource_name",
-                    "type": "string"
-                },
-                {
-                    "name": "output_format",
-                    "type": "NamespaceTerraformResourceOutputFormat_v1",
-                    "isInterface": true
-                },
-                {
-                    "name": "annotations",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceElastiCache_v1",
-            "interface": "NamespaceTerraformResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "identifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "defaults",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "parameter_group",
-                    "type": "string"
-                },
-                {
-                    "name": "region",
-                    "type": "string"
-                },
-                {
-                    "name": "overrides",
-                    "type": "json"
-                },
-                {
-                    "name": "output_resource_name",
-                    "type": "string"
-                },
-                {
-                    "name": "output_format",
-                    "type": "NamespaceTerraformResourceOutputFormat_v1",
-                    "isInterface": true
-                },
-                {
-                    "name": "annotations",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "SQSQueuesSpecs_v1",
-            "fields": [
-                {
-                    "name": "defaults",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "queues",
-                    "type": "KeyValue_v1",
-                    "isRequired": true,
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceSQS_v1",
-            "interface": "NamespaceTerraformResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "region",
-                    "type": "string"
-                },
-                {
-                    "name": "identifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "output_resource_name",
-                    "type": "string"
-                },
-                {
-                    "name": "output_format",
-                    "type": "NamespaceTerraformResourceOutputFormat_v1",
-                    "isInterface": true
-                },
-                {
-                    "name": "specs",
-                    "type": "SQSQueuesSpecs_v1",
-                    "isRequired": true,
-                    "isList": true
-                },
-                {
-                    "name": "annotations",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "DynamoDBTableSpecs_v1",
-            "fields": [
-                {
-                    "name": "defaults",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "tables",
-                    "type": "KeyValue_v1",
-                    "isRequired": true,
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceDynamoDB_v1",
-            "interface": "NamespaceTerraformResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "region",
-                    "type": "string"
-                },
-                {
-                    "name": "identifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "output_resource_name",
-                    "type": "string"
-                },
-                {
-                    "name": "output_format",
-                    "type": "NamespaceTerraformResourceOutputFormat_v1",
-                    "isInterface": true
-                },
-                {
-                    "name": "specs",
-                    "type": "DynamoDBTableSpecs_v1",
-                    "isRequired": true,
-                    "isList": true
-                },
-                {
-                    "name": "annotations",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceECR_v1",
-            "interface": "NamespaceTerraformResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "region",
-                    "type": "string"
-                },
-                {
-                    "name": "identifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "output_resource_name",
-                    "type": "string"
-                },
-                {
-                    "name": "output_format",
-                    "type": "NamespaceTerraformResourceOutputFormat_v1",
-                    "isInterface": true
-                },
-                {
-                    "name": "mirror",
-                    "type": "ContainerImageMirror_v1",
-                    "isRequired": false
-                },
-                {
-                    "name": "public",
-                    "type": "boolean"
-                },
-                {
-                    "name": "annotations",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceS3CloudFront_v1",
-            "interface": "NamespaceTerraformResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "region",
-                    "type": "string"
-                },
-                {
-                    "name": "identifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "defaults",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "output_resource_name",
-                    "type": "string"
-                },
-                {
-                    "name": "output_format",
-                    "type": "NamespaceTerraformResourceOutputFormat_v1",
-                    "isInterface": true
-                },
-                {
-                    "name": "storage_class",
-                    "type": "string"
-                },
-                {
-                    "name": "annotations",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceS3SQS_v1",
-            "interface": "NamespaceTerraformResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "region",
-                    "type": "string"
-                },
-                {
-                    "name": "identifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "kms_encryption",
-                    "type": "boolean"
-                },
-                {
-                    "name": "defaults",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "output_resource_name",
-                    "type": "string"
-                },
-                {
-                    "name": "output_format",
-                    "type": "NamespaceTerraformResourceOutputFormat_v1",
-                    "isInterface": true
-                },
-                {
-                    "name": "storage_class",
-                    "type": "string"
-                },
-                {
-                    "name": "annotations",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceCloudWatch_v1",
-            "interface": "NamespaceTerraformResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "region",
-                    "type": "string"
-                },
-                {
-                    "name": "identifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "defaults",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "es_identifier",
-                    "type": "string"
-                },
-                {
-                    "name": "filter_pattern",
-                    "type": "string"
-                },
-                {
-                    "name": "output_resource_name",
-                    "type": "string"
-                },
-                {
-                    "name": "output_format",
-                    "type": "NamespaceTerraformResourceOutputFormat_v1",
-                    "isInterface": true
-                },
-                {
-                    "name": "annotations",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceKMS_v1",
-            "interface": "NamespaceTerraformResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "region",
-                    "type": "string"
-                },
-                {
-                    "name": "identifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "defaults",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "overrides",
-                    "type": "json"
-                },
-                {
-                    "name": "output_resource_name",
-                    "type": "string"
-                },
-                {
-                    "name": "output_format",
-                    "type": "NamespaceTerraformResourceOutputFormat_v1",
-                    "isInterface": true
-                },
-                {
-                    "name": "annotations",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceKinesis_v1",
-            "interface": "NamespaceTerraformResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "region",
-                    "type": "string"
-                },
-                {
-                    "name": "identifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "defaults",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "overrides",
-                    "type": "json"
-                },
-                {
-                    "name": "output_resource_name",
-                    "type": "string"
-                },
-                {
-                    "name": "output_format",
-                    "type": "NamespaceTerraformResourceOutputFormat_v1",
-                    "isInterface": true
-                },
-                {
-                    "name": "annotations",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceALB_v1",
-            "interface": "NamespaceTerraformResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "identifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "region",
-                    "type": "string"
-                },
-                {
-                    "name": "vpc",
-                    "type": "AWSVPC_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "certificate_arn",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "idle_timeout",
-                    "type": "int"
-                },
-                {
-                    "name": "targets",
-                    "type": "NamespaceTerraformResourceALBTargets_v1",
-                    "isRequired": true,
-                    "isList": true
-                },
-                {
-                    "name": "rules",
-                    "type": "NamespaceTerraformResourceALBRules_v1",
-                    "isRequired": true,
-                    "isList": true
-                },
-                {
-                    "name": "vpc",
-                    "type": "AWSVPC_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "output_resource_name",
-                    "type": "string"
-                },
-                {
-                    "name": "output_format",
-                    "type": "NamespaceTerraformResourceOutputFormat_v1",
-                    "isInterface": true
-                },
-                {
-                    "name": "annotations",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceRoute53Zone_v1",
-            "interface": "NamespaceTerraformResource_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "region",
-                    "type": "string"
-                },
-                {
-                    "name": "identifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "output_resource_name",
-                    "type": "string"
-                },
-                {
-                    "name": "output_format",
-                    "type": "NamespaceTerraformResourceOutputFormat_v1",
-                    "isInterface": true
-                },
-                {
-                    "name": "annotations",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceALBTargets_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "default",
-                    "type": "boolean",
-                    "isRequired": true
-                },
-                {
-                    "name": "ips",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "openshift_service",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceALBRules_v1",
-            "fields": [
-                {
-                    "name": "condition",
-                    "type": "NamespaceTerraformResourceALBConditon_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "action",
-                    "type": "NamespaceTerraformResourceALBAction_v1",
-                    "isRequired": true,
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceALBConditon_v1",
-            "fields": [
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "methods",
-                    "type": "string",
-                    "isList": true,
-                    "isRequired": false
-                }
-            ]
-        },
-        {
-            "name": "NamespaceTerraformResourceALBAction_v1",
-            "fields": [
-                {
-                    "name": "target",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "weight",
-                    "type": "int",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "ResourceValues_v1",
-            "fields": [
-                {
-                    "name": "cpu",
-                    "type": "string"
-                },
-                {
-                    "name": "memory",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "LimitRangeItem_v1",
-            "fields": [
-                {
-                    "name": "default",
-                    "type": "ResourceValues_v1"
-                },
-                {
-                    "name": "defaultRequest",
-                    "type": "ResourceValues_v1"
-                },
-                {
-                    "name": "max",
-                    "type": "ResourceValues_v1"
-                },
-                {
-                    "name": "maxLimitRequestRatio",
-                    "type": "ResourceValues_v1"
-                },
-                {
-                    "name": "min",
-                    "type": "ResourceValues_v1"
-                },
-                {
-                    "name": "type",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "LimitRange_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "limits",
-                    "type": "LimitRangeItem_v1",
-                    "isList": true,
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "ResourceQuotaItemResources_v1",
-            "fields": [
-                {
-                    "name": "limits",
-                    "type": "ResourceValues_v1"
-                },
-                {
-                    "name": "requests",
-                    "type": "ResourceValues_v1"
-                },
-                {
-                    "name": "pods",
-                    "type": "int"
-                }
-            ]
-        },
-        {
-            "name": "ResourceQuotaItem_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "resources",
-                    "type": "ResourceQuotaItemResources_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "scopes",
-                    "type": "string",
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "ResourceQuota_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "quotas",
-                    "type": "ResourceQuotaItem_v1",
-                    "isList": true,
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "NamespaceManagedResourceTypeOverrides_v1",
-            "fields": [
-                {
-                    "name": "resource",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "override",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "NamespaceManagedResourceNames_v1",
-            "fields": [
-                {
-                    "name": "resource",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "resourceNames",
-                    "type": "string",
-                    "isRequired": true,
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "ServiceAccountTokenSpec_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string"
-                },
-                {
-                    "name": "namespace",
-                    "type": "Namespace_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "serviceAccountName",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "SharedResources_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true,
-                    "isSearchable": true,
-                    "isUnique": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "openshiftResources",
-                    "type": "NamespaceOpenshiftResource_v1",
-                    "isList": true,
-                    "isInterface": true,
-                    "isRequired": true
-                },
-                {
-                    "name": "openshiftServiceAccountTokens",
-                    "type": "ServiceAccountTokenSpec_v1",
-                    "isList": true
-                },
-                {
-                    "name": "terraformResources",
-                    "type": "NamespaceTerraformResource_v1",
-                    "isList": true,
-                    "isInterface": true
-                }
-            ]
-        },
-        {
-            "name": "Namespace_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "delete",
-                    "type": "boolean"
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "grafanaUrl",
-                    "type": "string"
-                },
-                {
-                    "name": "cluster",
-                    "type": "Cluster_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "app",
-                    "type": "App_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "environment",
-                    "type": "Environment_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "limitRanges",
-                    "type": "LimitRange_v1"
-                },
-                {
-                    "name": "quota",
-                    "type": "ResourceQuota_v1"
-                },
-                {
-                    "name": "networkPoliciesAllow",
-                    "type": "Namespace_v1",
-                    "isList": true
-                },
-                {
-                    "name": "clusterAdmin",
-                    "type": "boolean"
-                },
-                {
-                    "name": "managedRoles",
-                    "type": "boolean"
-                },
-                {
-                    "name": "managedResourceTypes",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "managedResourceTypeOverrides",
-                    "type": "NamespaceManagedResourceTypeOverrides_v1",
-                    "isList": true
-                },
-                {
-                    "name": "managedResourceNames",
-                    "type": "NamespaceManagedResourceNames_v1",
-                    "isList": true
-                },
-                {
-                    "name": "sharedResources",
-                    "type": "SharedResources_v1",
-                    "isList": true
-                },
-                {
-                    "name": "openshiftResources",
-                    "type": "NamespaceOpenshiftResource_v1",
-                    "isList": true,
-                    "isInterface": true
-                },
-                {
-                    "name": "managedTerraformResources",
-                    "type": "boolean"
-                },
-                {
-                    "name": "terraformResources",
-                    "type": "NamespaceTerraformResource_v1",
-                    "isList": true,
-                    "isInterface": true
-                },
-                {
-                    "name": "openshiftServiceAccountTokens",
-                    "type": "ServiceAccountTokenSpec_v1",
-                    "isList": true
-                },
-                {
-                    "name": "kafkaCluster",
-                    "type": "KafkaCluster_v1"
-                }
-            ]
-        },
-        {
-            "name": "Owner_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "email",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "Dependency_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "statefulness",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "opsModel",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "statusPage",
-                    "type": "string"
-                },
-                {
-                    "name": "SLA",
-                    "type": "float",
-                    "isRequired": true
-                },
-                {
-                    "name": "dependencyFailureImpact",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "AppGcrReposItems_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "public",
-                    "type": "boolean",
-                    "isRequired": true
-                },
-                {
-                    "name": "mirror",
-                    "type": "ContainerImageMirror_v1",
-                    "isRequired": false
-                }
-            ]
-        },
-        {
-            "name": "OcpReleaseMirror_v1",
-            "fields": [
-                {
-                    "name": "hiveCluster",
-                    "type": "Cluster_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "ecrResourcesNamespace",
-                    "type": "Namespace_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "ocpReleaseEcrIdentifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "ocpArtDevEcrIdentifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "quayTargetOrgs",
-                    "type": "QuayOrg_v1",
-                    "isRequired": true,
-                    "isList": true
-                },
-                {
-                    "name": "mirrorChannels",
-                    "type": "string",
-                    "isRequired": true,
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "ContainerImageMirror_v1",
-            "fields": [
-                {
-                    "name": "url",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "pullCredentials",
-                    "type": "VaultSecret_v1"
-                },
-                {
-                    "name": "tags",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "tagsExclude",
-                    "type": "string",
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "AppGcrRepos_v1",
-            "fields": [
-                {
-                    "name": "project",
-                    "type": "GcpProject_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "items",
-                    "type": "AppGcrReposItems_v1",
-                    "isRequired": true,
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "AppQuayReposItems_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "public",
-                    "type": "boolean",
-                    "isRequired": true
-                },
-                {
-                    "name": "mirror",
-                    "type": "ContainerImageMirror_v1",
-                    "isRequired": false
-                }
-            ]
-        },
-        {
-            "name": "AppQuayReposTeams_v1",
-            "fields": [
-                {
-                    "name": "permissions",
-                    "type": "PermissionQuayOrgTeam_v1",
-                    "isList": true,
-                    "isRequired": true
-                },
-                {
-                    "name": "role",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "AppQuayReposNotificationVerificationMethod_v1",
-            "fields": [
-                {
-                    "name": "jiraBoard",
-                    "type": "JiraBoard_v1"
-                }
-            ]
-        },
-        {
-            "name": "AppQuayReposNotifications_v1",
-            "fields": [
-                {
-                    "name": "event",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "severity",
-                    "type": "string"
-                },
-                {
-                    "name": "method",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "escalationPolicy",
-                    "type": "AppEscalationPolicy_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "verificationMethod",
-                    "type": "AppQuayReposNotificationVerificationMethod_v1"
-                }
-            ]
-        },
-        {
-            "name": "AppQuayRepos_v1",
-            "fields": [
-                {
-                    "name": "org",
-                    "type": "QuayOrg_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "teams",
-                    "type": "AppQuayReposTeams_v1",
-                    "isList": true
-                },
-                {
-                    "name": "notifications",
-                    "type": "AppQuayReposNotifications_v1",
-                    "isList": true
-                },
-                {
-                    "name": "items",
-                    "type": "AppQuayReposItems_v1",
-                    "isRequired": true,
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "AppEscalationPolicy_v1",
-            "fields": [
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "channels",
-                    "type": "AppEscalationPolicyChannels_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "AppEscalationPolicyChannels_v1",
-            "fields": [
-                {
-                    "name": "slackUserGroup",
-                    "type": "PermissionSlackUsergroup_v1",
-                    "isList": true,
-                    "isRequired": true
-                },
-                {
-                    "name": "email",
-                    "type": "string",
-                    "isList": true,
-                    "isRequired": true
-                },
-                {
-                    "name": "pagerduty",
-                    "type": "PagerDutyTarget_v1"
-                },
-                {
-                    "name": "jiraBoard",
-                    "type": "JiraBoard_v1",
-                    "isList": true,
-                    "isRequired": true
-                },
-                {
-                    "name": "nextEscalationPolicy",
-                    "type": "AppEscalationPolicy_v1"
-                }
-            ]
-        },
-        {
-            "name": "AppEndPoints_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "url",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "monitoring",
-                    "type": "AppEndPointMonitoring_v1",
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "AppEndPointMonitoring_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "EndpointMonitoringProvider_v1",
-                    "isInterface": true
-                }
-            ]
-        },
-        {
-            "name": "CodeComponentGitlabOwners_v1",
-            "fields": [
-                {
-                    "name": "enabled",
-                    "type": "boolean",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "CodeComponentGitlabHousekeeping_v1",
-            "fields": [
-                {
-                    "name": "enabled",
-                    "type": "boolean",
-                    "isRequired": true
-                },
-                {
-                    "name": "rebase",
-                    "type": "boolean",
-                    "isRequired": true
-                },
-                {
-                    "name": "days_interval",
-                    "type": "int"
-                },
-                {
-                    "name": "limit",
-                    "type": "int"
-                },
-                {
-                    "name": "enable_closing",
-                    "type": "boolean"
-                },
-                {
-                    "name": "pipeline_timeout",
-                    "type": "int"
-                }
-            ]
-        },
-        {
-            "name": "AppCodeComponents_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "resource",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "url",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "gitlabRepoOwners",
-                    "type": "CodeComponentGitlabOwners_v1"
-                },
-                {
-                    "name": "gitlabHousekeeping",
-                    "type": "CodeComponentGitlabHousekeeping_v1"
-                },
-                {
-                    "name": "jira",
-                    "type": "JiraServer_v1"
-                }
-            ]
-        },
-        {
-            "name": "Product_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "productOwners",
-                    "type": "Owner_v1",
-                    "isList": true,
-                    "isRequired": true
-                },
-                {
-                    "name": "environments",
-                    "type": "Environment_v1",
-                    "isList": true,
-                    "synthetic": {
-                        "schema": "/app-sre/environment-1.yml",
-                        "subAttr": "product"
+            {
+                "name": "AppInterfaceEmailAudience_v1",
+                "fields": [
+                    {
+                        "name": "aliases",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "services",
+                        "type": "App_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "clusters",
+                        "type": "Cluster_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "namespaces",
+                        "type": "Namespace_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "aws_accounts",
+                        "type": "AWSAccount_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "roles",
+                        "type": "Role_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "users",
+                        "type": "User_v1",
+                        "isList": true
                     }
-                }
-            ]
-        },
-        {
-            "name": "Environment_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "product",
-                    "type": "Product_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "parameters",
-                    "type": "json"
-                },
-                {
-                    "name": "secretParameters",
-                    "type": "SaasSecretParameters_v1",
-                    "isList": true
-                },
-                {
-                    "name": "dependsOn",
-                    "type": "Environment_v1"
-                },
-                {
-                    "name": "namespaces",
-                    "type": "Namespace_v1",
-                    "isList": true,
-                    "synthetic": {
-                        "schema": "/openshift/namespace-1.yml",
-                        "subAttr": "environment"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "App_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true,
-                    "isSearchable": true,
-                    "isUnique": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "onboardingStatus",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "grafanaUrls",
-                    "isList": true,
-                    "type": "GrafanaDashboardUrls_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "sopsUrl",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "architectureDocument",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "parentApp",
-                    "type": "App_v1"
-                },
-                {
-                    "name": "serviceDocs",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "serviceOwners",
-                    "type": "Owner_v1",
-                    "isList": true,
-                    "isRequired": true
-                },
-                {
-                    "name": "serviceNotifications",
-                    "type": "Owner_v1",
-                    "isList": true
-                },
-                {
-                    "name": "dependencies",
-                    "type": "Dependency_v1",
-                    "isList": true
-                },
-                {
-                    "name": "gcrRepos",
-                    "type": "AppGcrRepos_v1",
-                    "isList": true
-                },
-                {
-                    "name": "quayRepos",
-                    "type": "AppQuayRepos_v1",
-                    "isList": true
-                },
-                {
-                    "name": "escalationPolicy",
-                    "type": "AppEscalationPolicy_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "endPoints",
-                    "type": "AppEndPoints_v1",
-                    "isList": true
-                },
-                {
-                    "name": "codeComponents",
-                    "type": "AppCodeComponents_v1",
-                    "isList": true
-                },
-                {
-                    "name": "sentryProjects",
-                    "type": "AppSentryProjects_v1",
-                    "isList": true
-                },
-                {
-                    "name": "statusPageComponents",
-                    "type": "StatusPageComponent_v1",
-                    "isList": true
-                },
-                {
-                    "name": "namespaces",
-                    "type": "Namespace_v1",
-                    "isList": true,
-                    "synthetic": {
-                        "schema": "/openshift/namespace-1.yml",
-                        "subAttr": "app"
-                    }
-                },
-                {
-                    "name": "childrenApps",
-                    "type": "App_v1",
-                    "isList": true,
-                    "synthetic": {
-                        "schema": "/app-sre/app-1.yml",
-                        "subAttr": "parentApp"
-                    }
-                },
-                {
-                    "name": "jenkinsConfigs",
-                    "type": "JenkinsConfig_v1",
-                    "isList": true,
-                    "synthetic": {
-                        "schema": "/dependencies/jenkins-config-1.yml",
-                        "subAttr": "app"
-                    }
-                },
-                {
-                    "name": "saasFiles",
-                    "type": "SaasFile_v2",
-                    "isList": true,
-                    "synthetic": {
-                        "schema": "/app-sre/saas-file-2.yml",
-                        "subAttr": "app"
-                    }
-                },
-                {
-                    "name": "sreCheckpoints",
-                    "type": "SRECheckpoint_v1",
-                    "isList": true,
-                    "synthetic": {
-                        "schema": "/app-sre/sre-checkpoint-1.yml",
-                        "subAttr": "app"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "SaasFile_v2",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true,
-                    "isSearchable": true,
-                    "isUnique": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "app",
-                    "type": "App_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "pipelinesProvider",
-                    "type": "PipelinesProvider_v1",
-                    "isRequired": true,
-                    "isInterface": true
-                },
-                {
-                    "name": "slack",
-                    "type": "SlackOutput_v1"
-                },
-                {
-                    "name": "managedResourceTypes",
-                    "type": "string",
-                    "isRequired": true,
-                    "isList": true
-                },
-                {
-                    "name": "authentication",
-                    "type": "SaasFileAuthentication_v1"
-                },
-                {
-                    "name": "parameters",
-                    "type": "json"
-                },
-                {
-                    "name": "secretParameters",
-                    "type": "SaasSecretParameters_v1",
-                    "isList": true
-                },
-                {
-                    "name": "resourceTemplates",
-                    "type": "SaasResourceTemplate_v2",
-                    "isRequired": true,
-                    "isList": true
-                },
-                {
-                    "name": "imagePatterns",
-                    "type": "string",
-                    "isRequired": true,
-                    "isList": true
-                },
-                {
-                    "name": "takeover",
-                    "type": "boolean"
-                },
-                {
-                    "name": "compare",
-                    "type": "boolean"
-                },
-                {
-                    "name": "publishJobLogs",
-                    "type": "boolean"
-                },
-                {
-                    "name": "clusterAdmin",
-                    "type": "boolean"
-                },
-                {
-                    "name": "use_channel_in_image_tag",
-                    "type": "boolean"
-                },
-                {
-                    "name": "configurableResources",
-                    "type": "boolean"
-                },
-                {
-                    "name": "deployResources",
-                    "type": "DeployResources_v1"
-                },
-                {
-                    "name": "roles",
-                    "type": "Role_v1",
-                    "isList": true,
-                    "synthetic": {
-                        "schema": "/access/role-1.yml",
-                        "subAttr": "owned_saas_files"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "DeployResources_v1",
-            "fields": [
-                {
-                    "name": "requests",
-                    "type": "ResourceRequirements_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "limits",
-                    "type": "ResourceRequirements_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "ResourceRequirements_v1",
-            "fields": [
-                {
-                    "name": "cpu",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "memory",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "SlackOutputNotifications_v1",
-            "fields": [
-                {
-                    "name": "start",
-                    "type": "boolean"
-                }
-            ]
-        },
-        {
-            "name": "SlackOutput_v1",
-            "fields": [
-                {
-                    "name": "workspace",
-                    "type": "SlackWorkspace_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "channel",
-                    "type": "string"
-                },
-                {
-                    "name": "icon_emoji",
-                    "type": "string"
-                },
-                {
-                    "name": "username",
-                    "type": "string"
-                },
-                {
-                    "name": "output",
-                    "type": "string"
-                },
-                {
-                    "name": "notifications",
-                    "type": "SlackOutputNotifications_v1"
-                }
-            ]
-        },
-        {
-            "name": "SaasFileAuthentication_v1",
-            "fields": [
-                {
-                    "name": "code",
-                    "type": "VaultSecret_v1"
-                },
-                {
-                    "name": "image",
-                    "type": "VaultSecret_v1"
-                }
-            ]
-        },
-        {
-            "name": "SaasResourceTemplate_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "url",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "provider",
-                    "type": "string"
-                },
-                {
-                    "name": "hash_length",
-                    "type": "int"
-                },
-                {
-                    "name": "parameters",
-                    "type": "json"
-                },
-                {
-                    "name": "secretParameters",
-                    "type": "SaasSecretParameters_v1",
-                    "isList": true
-                },
-                {
-                    "name": "targets",
-                    "type": "SaasResourceTemplateTarget_v1",
-                    "isRequired": true,
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "SaasResourceTemplate_v2",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "url",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "provider",
-                    "type": "string"
-                },
-                {
-                    "name": "hash_length",
-                    "type": "int"
-                },
-                {
-                    "name": "parameters",
-                    "type": "json"
-                },
-                {
-                    "name": "secretParameters",
-                    "type": "SaasSecretParameters_v1",
-                    "isList": true
-                },
-                {
-                    "name": "targets",
-                    "type": "SaasResourceTemplateTarget_v2",
-                    "isRequired": true,
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "SaasResourceTemplateTarget_v1",
-            "fields": [
-                {
-                    "name": "namespace",
-                    "type": "Namespace_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "ref",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "promotion",
-                    "type": "SaasResourceTemplateTargetPromotion_v1"
-                },
-                {
-                    "name": "parameters",
-                    "type": "json"
-                },
-                {
-                    "name": "secretParameters",
-                    "type": "SaasSecretParameters_v1",
-                    "isList": true
-                },
-                {
-                    "name": "upstream",
-                    "type": "string"
-                },
-                {
-                    "name": "disable",
-                    "type": "boolean"
-                },
-                {
-                    "name": "delete",
-                    "type": "boolean"
-                }
-            ]
-        },
-        {
-            "name": "SaasResourceTemplateTarget_v2",
-            "fields": [
-                {
-                    "name": "namespace",
-                    "type": "Namespace_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "ref",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "promotion",
-                    "type": "SaasResourceTemplateTargetPromotion_v1"
-                },
-                {
-                    "name": "parameters",
-                    "type": "json"
-                },
-                {
-                    "name": "secretParameters",
-                    "type": "SaasSecretParameters_v1",
-                    "isList": true
-                },
-                {
-                    "name": "upstream",
-                    "type": "SaasResourceTemplateTargetUpstream_v1"
-                },
-                {
-                    "name": "disable",
-                    "type": "boolean"
-                },
-                {
-                    "name": "delete",
-                    "type": "boolean"
-                }
-            ]
-        },
-        {
-            "name": "SaasResourceTemplateTargetUpstream_v1",
-            "fields": [
-                {
-                    "name": "instance",
-                    "type": "JenkinsInstance_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "SaasResourceTemplateTargetPromotion_v1",
-            "fields": [
-                {
-                    "name": "auto",
-                    "type": "boolean"
-                },
-                {
-                    "name": "publish",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "subscribe",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "promotion_data",
-                    "type": "PromotionData_v1",
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "SaasSecretParameters_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "secret",
-                    "type": "VaultSecret_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "PromotionData_v1",
-            "fields": [
-                {
-                    "name": "channel",
-                    "type": "string"
-                },
-                {
-                    "name": "data",
-                    "type": "PromotionChannelData_v1",
-                    "isList": true,
-                    "isInterface": true
-                }
-            ]
-        },
-        {
-            "name": "PromotionChannelData_v1",
-            "isInterface": true,
-            "interfaceResolve": {
-                "strategy": "fieldMap",
-                "field": "type",
-                "fieldMap": {
-                    "parent_saas_config": "ParentSaasPromotion_v1"
-                }
+                ]
             },
-            "fields": [
-                {
-                    "name": "type",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "ParentSaasPromotion_v1",
-            "interface": "PromotionChannelData_v1",
-            "fields": [
-                {
-                    "name": "type",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "parent_saas",
-                    "type": "string"
-                },
-                {
-                    "name": "target_config_hash",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "PipelinesProvider_v1",
-            "isInterface": true,
-            "interfaceResolve": {
-                "strategy": "fieldMap",
-                "field": "provider",
-                "fieldMap": {
-                    "tekton": "PipelinesProviderTekton_v1"
-                }
+            {
+                "name": "AppInterfaceSlackNotification_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "subject",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "channel",
+                        "type": "string"
+                    },
+                    {
+                        "name": "to",
+                        "type": "AppInterfaceSlackNotificationAudience_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "body",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
             },
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "PipelinesProviderTekton_v1",
-            "interface": "PipelinesProvider_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "defaults",
-                    "type": "PipelinesProviderTektonProviderDefaults_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "namespace",
-                    "type": "Namespace_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "retention",
-                    "type": "PipelinesProviderRetention_v1"
-                },
-                {
-                    "name": "taskTemplates",
-                    "type": "PipelinesProviderTektonObjectTemplate_v1",
-                    "isList": true
-                },
-                {
-                    "name": "pipelineTemplates",
-                    "type": "PipelinesProviderPipelineTemplates_v1"
-                },
-                {
-                    "name": "deployResources",
-                    "type": "DeployResources_v1"
-                }
-            ]
-        },
-        {
-            "name": "PipelinesProviderRetention_v1",
-            "fields": [
-                {
-                    "name": "days",
-                    "type": "int"
-                },
-                {
-                    "name": "minimum",
-                    "type": "int"
-                }
-            ]
-        },
-        {
-            "name": "PipelinesProviderTektonObjectTemplate_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "type",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "variables",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "PipelinesProviderPipelineTemplates_v1",
-            "fields": [
-                {
-                    "name": "openshiftSaasDeploy",
-                    "type": "PipelinesProviderTektonObjectTemplate_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "PipelinesProviderTektonProviderDefaults_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "retention",
-                    "type": "PipelinesProviderRetention_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "taskTemplates",
-                    "type": "PipelinesProviderTektonObjectTemplate_v1",
-                    "isRequired": true,
-                    "isList": true
-                },
-                {
-                    "name": "pipelineTemplates",
-                    "type": "PipelinesProviderPipelineTemplates_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "deployResources",
-                    "type": "DeployResources_v1"
-                }
-            ]
-        },
-        {
-            "name": "VaultInstance_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "address",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "auth",
-                    "type": "VaultInstanceAuth_v1",
-                    "isInterface": true,
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "VaultInstanceAuth_v1",
-            "isInterface": true,
-            "interfaceResolve": {
-                "strategy": "fieldMap",
-                "field": "provider",
-                "fieldMap": {
-                    "approle": "VaultInstanceAuthApprole_v1",
-                    "token": "VaultInstanceAuthToken_v1"
-                }
+            {
+                "name": "AppInterfaceSlackNotificationAudience_v1",
+                "fields": [
+                    {
+                        "name": "users",
+                        "type": "string",
+                        "isList": true
+                    }
+                ]
             },
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
+            {
+                "name": "VaultAuditOptions_v1",
+                "isInterface": true,
+                "interfaceResolve": {
+                    "strategy": "fieldMap",
+                    "field": "_type",
+                    "fieldMap": {
+                        "file": "VaultAuditOptionsFile_v1"
+                    }
                 },
-                {
-                    "name": "secretEngine",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "VaultInstanceAuthApprole_v1",
-            "interface": "VaultInstanceAuth_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "secretEngine",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "roleID",
-                    "type": "VaultSecret_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "secretID",
-                    "type": "VaultSecret_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "VaultInstanceAuthToken_v1",
-            "interface": "VaultInstanceAuth_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "secretEngine",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "token",
-                    "type": "VaultSecret_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "OidcPermission_v1",
-            "isInterface": true,
-            "interfaceResolve": {
-                "strategy": "fieldMap",
-                "field": "service",
-                "fieldMap": {
-                    "vault": "OidcPermissionVault_v1"
-                }
+                "fields": [
+                    {
+                        "name": "_type",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
             },
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "service",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "OidcPermissionVault_v1",
-            "interface": "OidcPermission_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "service",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "instance",
-                    "type": "VaultInstance_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "vault_policies",
-                    "type": "VaultPolicy_v1",
-                    "isList": true,
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "Permission_v1",
-            "isInterface": true,
-            "interfaceResolve": {
-                "strategy": "fieldMap",
-                "field": "service",
-                "fieldMap": {
-                    "github-org": "PermissionGithubOrg_v1",
-                    "github-org-team": "PermissionGithubOrgTeam_v1",
-                    "quay-membership": "PermissionQuayOrgTeam_v1",
-                    "jenkins-role": "PermissionJenkinsRole_v1",
-                    "slack-usergroup": "PermissionSlackUsergroup_v1",
-                    "gitlab-group-membership": "PermissionGitlabGroupMembership_v1"
-                }
+            {
+                "name": "VaultAuditOptionsFile_v1",
+                "interface": "VaultAuditOptions_v1",
+                "fields": [
+                    {
+                        "name": "_type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "file_path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "log_raw",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "hmac_accessor",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "mode",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "format",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "prefix",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
             },
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "service",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "PermissionGithubOrg_v1",
-            "interface": "Permission_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "service",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "org",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "role",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "PermissionGithubOrgTeam_v1",
-            "interface": "Permission_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "service",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "org",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "team",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "role",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "PermissionJenkinsRole_v1",
-            "interface": "Permission_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "service",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "instance",
-                    "type": "JenkinsInstance_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "role",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "token",
-                    "type": "VaultSecret_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "PermissionGitlabGroupMembership_v1",
-            "interface": "Permission_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "service",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "group",
-                    "type": "string",
-                    "isRequried": true
-                },
-                {
-                    "name": "access",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "PermissionSlackUsergroup_v1",
-            "interface": "Permission_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "service",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "handle",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "workspace",
-                    "type": "SlackWorkspace_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "pagerduty",
-                    "type": "PagerDutyTarget_v1",
-                    "isList": true
-                },
-                {
-                    "name": "channels",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "ownersFromRepos",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "schedule",
-                    "type": "Schedule_v1"
-                },
-                {
-                    "name": "skip",
-                    "type": "boolean"
-                },
-                {
-                    "name": "roles",
-                    "type": "Role_v1",
-                    "isList": true,
-                    "synthetic": {
-                        "schema": "/access/role-1.yml",
-                        "subAttr": "permissions"
+            {
+                "name": "VaultAudit_v1",
+                "fields": [
+                    {
+                        "name": "_path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "instance",
+                        "type": "VaultInstance_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "options",
+                        "type": "VaultAuditOptions_v1",
+                        "isInterface": true,
+                        "isRequired": true
                     }
-                }
-            ]
-        },
-        {
-            "name": "Schedule_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string"
-                },
-                {
-                    "name": "schedule",
-                    "type": "ScheduleEntry_v1",
-                    "isRequired": true,
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "ScheduleEntry_v1",
-            "fields": [
-                {
-                    "name": "start",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "end",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "users",
-                    "type": "User_v1",
-                    "isRequired": true,
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "VaultPolicyMapping_v1",
-            "fields": [
-                {
-                    "name": "github_team",
-                    "type": "PermissionGithubOrgTeam_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "policies",
-                    "type": "VaultPolicy_v1",
-                    "isList": true,
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "VaultAuth_v1",
-            "fields": [
-                {
-                    "name": "_path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "type",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "instance",
-                    "type": "VaultInstance_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "settings",
-                    "type": "VaultAuthSettings_v1"
-                },
-                {
-                    "name": "policy_mappings",
-                    "type": "VaultPolicyMapping_v1",
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "PermissionQuayOrgTeam_v1",
-            "interface": "Permission_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "service",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "quayOrg",
-                    "type": "QuayOrg_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "team",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "ExternalUser_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "github_username",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "sponsors",
-                    "type": "User_v1",
-                    "isRequired": true,
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "User_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "org_username",
-                    "type": "string",
-                    "isSearchable": true,
-                    "isRequired": true,
-                    "isUnique": true
-                },
-                {
-                    "name": "github_username",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "quay_username",
-                    "type": "string"
-                },
-                {
-                    "name": "slack_username",
-                    "type": "string"
-                },
-                {
-                    "name": "pagerduty_username",
-                    "type": "string"
-                },
-                {
-                    "name": "aws_username",
-                    "type": "string"
-                },
-                {
-                    "name": "public_gpg_key",
-                    "type": "string"
-                },
-                {
-                    "name": "tag_on_merge_requests",
-                    "type": "boolean"
-                },
-                {
-                    "name": "tag_on_cluster_updates",
-                    "type": "boolean"
-                },
-                {
-                    "name": "roles",
-                    "type": "Role_v1",
-                    "isList": true
-                },
-                {
-                    "name": "requests",
-                    "type": "CredentialsRequest_v1",
-                    "isList": true,
-                    "synthetic": {
-                        "schema": "/app-interface/credentials-request-1.yml",
-                        "subAttr": "user"
-                    }
-                },
-                {
-                    "name": "queries",
-                    "type": "AppInterfaceSqlQuery_v1",
-                    "isList": true,
-                    "synthetic": {
-                        "schema": "/app-interface/app-interface-sql-query-1.yml",
-                        "subAttr": "user"
-                    }
-                },
-                {
-                    "name": "gabi_instances",
-                    "type": "GabiInstance_v1",
-                    "isList": true,
-                    "synthetic": {
-                        "schema": "/app-sre/gabi-instance-1.yml",
-                        "subAttr": "users"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "Bot_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string"
-                },
-                {
-                    "name": "org_username",
-                    "type": "string"
-                },
-                {
-                    "name": "github_username",
-                    "type": "string"
-                },
-                {
-                    "name": "gitlab_username",
-                    "type": "string"
-                },
-                {
-                    "name": "openshift_serviceaccount",
-                    "type": "string"
-                },
-                {
-                    "name": "quay_username",
-                    "type": "string"
-                },
-                {
-                    "name": "owner",
-                    "type": "User_v1"
-                },
-                {
-                    "name": "roles",
-                    "type": "Role_v1",
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "Access_v1",
-            "fields": [
-                {
-                    "name": "namespace",
-                    "type": "Namespace_v1"
-                },
-                {
-                    "name": "role",
-                    "type": "string"
-                },
-                {
-                    "name": "cluster",
-                    "type": "Cluster_v1"
-                },
-                {
-                    "name": "group",
-                    "type": "string"
-                },
-                {
-                    "name": "clusterRole",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "Role_v1",
-            "datafile": "/access/role-1.yml",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true,
-                    "isUnique": true,
-                    "isSearchable": true
-                },
-                {
-                    "name": "description",
-                    "type": "string"
-                },
-                {
-                    "name": "expirationDate",
-                    "type": "string"
-                },
-                {
-                    "name": "permissions",
-                    "type": "Permission_v1",
-                    "isList": true,
-                    "isInterface": true
-                },
-                {
-                    "name": "oidc_permissions",
-                    "type": "OidcPermission_v1",
-                    "isList": true,
-                    "isInterface": true
-                },
-                {
-                    "name": "tag_on_cluster_updates",
-                    "type": "boolean"
-                },
-                {
-                    "name": "access",
-                    "type": "Access_v1",
-                    "isList": true
-                },
-                {
-                    "name": "aws_groups",
-                    "type": "AWSGroup_v1",
-                    "isList": true
-                },
-                {
-                    "name": "user_policies",
-                    "type": "AWSUserPolicy_v1",
-                    "isList": true
-                },
-                {
-                    "name": "sentry_teams",
-                    "type": "SentryTeam_v1",
-                    "isList": true
-                },
-                {
-                    "name": "sentry_roles",
-                    "type": "SentryRole_v1",
-                    "isList": true
-                },
-                {
-                    "name": "sendgrid_accounts",
-                    "type": "SendGridAccount_v1",
-                    "isList": true
-                },
-                {
-                    "name": "owned_saas_files",
-                    "type": "SaasFile_v2",
-                    "isList": true
-                },
-                {
-                    "name": "users",
-                    "type": "User_v1",
-                    "isList": true,
-                    "synthetic": {
-                        "schema": "/access/user-1.yml",
-                        "subAttr": "roles"
-                    }
-                },
-                {
-                    "name": "bots",
-                    "type": "Bot_v1",
-                    "isList": true,
-                    "synthetic": {
-                        "schema": "/access/bot-1.yml",
-                        "subAttr": "roles"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "IntegrationPrCheck_v1",
-            "fields": [
-                {
-                    "name": "cmd",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "state",
-                    "type": "boolean"
-                },
-                {
-                    "name": "sqs",
-                    "type": "boolean"
-                },
-                {
-                    "name": "disabled",
-                    "type": "boolean"
-                },
-                {
-                    "name": "always_run",
-                    "type": "boolean"
-                },
-                {
-                    "name": "no_validate_schemas",
-                    "type": "boolean"
-                },
-                {
-                    "name": "run_for_valid_saas_file_changes",
-                    "type": "boolean"
-                }
-            ]
-        },
-        {
-            "name": "IntegrationSpecExtraEnv_v1",
-            "fields": [
-                {
-                    "name": "secretName",
-                    "type": "string"
-                },
-                {
-                    "name": "secretKey",
-                    "type": "string"
-                },
-                {
-                    "name": "name",
-                    "type": "string"
-                },
-                {
-                    "name": "value",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "IntegrationSpecLogs_v1",
-            "fields": [
-                {
-                    "name": "slack",
-                    "type": "boolean"
-                }
-            ]
-        },
-        {
-            "name": "IntegrationSpec_v1",
-            "fields": [
-                {
-                    "name": "cache",
-                    "type": "boolean"
-                },
-                {
-                    "name": "command",
-                    "type": "string"
-                },
-                {
-                    "name": "disableUnleash",
-                    "type": "boolean"
-                },
-                {
-                    "name": "environmentAware",
-                    "type": "boolean"
-                },
-                {
-                    "name": "extraArgs",
-                    "type": "string"
-                },
-                {
-                    "name": "extraEnv",
-                    "type": "IntegrationSpecExtraEnv_v1",
-                    "isList": true
-                },
-                {
-                    "name": "internalCertificates",
-                    "type": "boolean"
-                },
-                {
-                    "name": "logs",
-                    "type": "IntegrationSpecLogs_v1"
-                },
-                {
-                    "name": "resources",
-                    "type": "DeployResources_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "shards",
-                    "type": "int"
-                },
-                {
-                    "name": "sleepDurationSecs",
-                    "type": "int"
-                },
-                {
-                    "name": "state",
-                    "type": "boolean"
-                },
-                {
-                    "name": "storage",
-                    "type": "string"
-                },
-                {
-                    "name": "trigger",
-                    "type": "boolean"
-                },
-                {
-                    "name": "cron",
-                    "type": "string"
-                },
-                {
-                    "name": "dashdotdb",
-                    "type": "boolean"
-                },
-                {
-                    "name": "concurrencyPolicy",
-                    "type": "string"
-                },
-                {
-                    "name": "restartPolicy",
-                    "type": "string"
-                },
-                {
-                    "name": "successfulJobHistoryLimit",
-                    "type": "int"
-                },
-                {
-                    "name": "failedJobHistoryLimit",
-                    "type": "int"
-                }
-            ]
-        },
-        {
-            "name": "IntegrationManaged_v1",
-            "fields": [
-                {
-                    "name": "namespace",
-                    "type": "Namespace_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "spec",
-                    "type": "IntegrationSpec_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "Integration_v1",
-            "datafile": "/app-sre/integration-1.yml",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "upstream",
-                    "type": "string"
-                },
-                {
-                    "name": "schemas",
-                    "type": "string",
-                    "isRequired": true,
-                    "isList": true
-                },
-                {
-                    "name": "pr_check",
-                    "type": "IntegrationPrCheck_v1"
-                },
-                {
-                    "name": "managed",
-                    "type": "IntegrationManaged_v1",
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "Document_v1",
-            "datafile": "/app-sre/document-1.yml",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "app",
-                    "type": "App_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "content_path",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "Report_v1",
-            "datafile": "/app-sre/report-1.yml",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "app",
-                    "type": "App_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "date",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "contentFormatVersion",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "content",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "SRECheckpoint_v1",
-            "datafile": "/app-sre/sre-checkpoint-1.yml",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "app",
-                    "type": "App_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "date",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "issue",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "AppInterfaceSqlQuery_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "namespace",
-                    "type": "Namespace_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "identifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "requestor",
-                    "type": "User_v1"
-                },
-                {
-                    "name": "overrides",
-                    "type": "SqlEmailOverrides_v1"
-                },
-                {
-                    "name": "output",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "schedule",
-                    "type": "string"
-                },
-                {
-                    "name": "query",
-                    "type": "string"
-                },
-                {
-                    "name": "queries",
-                    "type": "string",
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "UnleashNotifications_v1",
-            "fields": [
-                {
-                    "name": "slack",
-                    "type": "SlackOutput_v1",
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "UnleashFeatureToggle_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "enabled",
-                    "type": "boolean",
-                    "isRequired": true
-                },
-                {
-                    "name": "reason",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "UnleashInstance_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "url",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "token",
-                    "type": "VaultSecret_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "notifications",
-                    "type": "UnleashNotifications_v1"
-                },
-                {
-                    "name": "featureToggles",
-                    "type": "UnleashFeatureToggle_v1",
-                    "isRequired": true,
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "GabiNamespace_v1",
-            "fields": [
-                {
-                    "name": "account",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "identifier",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "namespace",
-                    "type": "Namespace_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "GabiInstance_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "signoffManagers",
-                    "type": "User_v1",
-                    "isRequired": true,
-                    "isList": true
-                },
-                {
-                    "name": "users",
-                    "type": "User_v1",
-                    "isRequired": true,
-                    "isList": true
-                },
-                {
-                    "name": "instances",
-                    "type": "GabiNamespace_v1",
-                    "isRequired": true,
-                    "isList": true
-                },
-                {
-                    "name": "expirationDate",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "TemplateTest_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "resourcePath",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "expectedResult",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "Query",
-            "fields": [
-                {
-                    "name": "app_interface_settings_v1",
-                    "type": "AppInterfaceSettings_v1",
-                    "isList": true,
-                    "datafileSchema": "/app-interface/app-interface-settings-1.yml"
-                },
-                {
-                    "name": "app_interface_emails_v1",
-                    "type": "AppInterfaceEmail_v1",
-                    "isList": true,
-                    "datafileSchema": "/app-interface/app-interface-email-1.yml"
-                },
-                {
-                    "name": "app_interface_slack_notifications_v1",
-                    "type": "AppInterfaceSlackNotification_v1",
-                    "isList": true,
-                    "datafileSchema": "/app-interface/app-interface-slack-notification-1.yml"
-                },
-                {
-                    "name": "credentials_requests_v1",
-                    "type": "CredentialsRequest_v1",
-                    "isList": true,
-                    "datafileSchema": "/app-interface/credentials-request-1.yml"
-                },
-                {
-                    "name": "users_v1",
-                    "type": "User_v1",
-                    "isList": true,
-                    "datafileSchema": "/access/user-1.yml"
-                },
-                {
-                    "name": "external_users_v1",
-                    "type": "ExternalUser_v1",
-                    "isList": true,
-                    "datafileSchema": "/access/external-user-1.yml"
-                },
-                {
-                    "name": "bots_v1",
-                    "type": "Bot_v1",
-                    "isList": true,
-                    "datafileSchema": "/access/bot-1.yml"
-                },
-                {
-                    "name": "roles_v1",
-                    "type": "Role_v1",
-                    "isList": true,
-                    "datafileSchema": "/access/role-1.yml"
-                },
-                {
-                    "name": "permissions_v1",
-                    "type": "Permission_v1",
-                    "isList": true,
-                    "isInterface": true,
-                    "datafileSchema": "/access/permission-1.yml"
-                },
-                {
-                    "name": "awsgroups_v1",
-                    "type": "AWSGroup_v1",
-                    "isList": true,
-                    "datafileSchema": "/aws/group-1.yml"
-                },
-                {
-                    "name": "awsaccounts_v1",
-                    "type": "AWSAccount_v1",
-                    "isList": true,
-                    "datafileSchema": "/aws/account-1.yml"
-                },
-                {
-                    "name": "clusters_v1",
-                    "type": "Cluster_v1",
-                    "isList": true,
-                    "datafileSchema": "/openshift/cluster-1.yml"
-                },
-                {
-                    "name": "kafka_clusters_v1",
-                    "type": "KafkaCluster_v1",
-                    "isList": true,
-                    "datafileSchema": "/kafka/cluster-1.yml"
-                },
-                {
-                    "name": "namespaces_v1",
-                    "type": "Namespace_v1",
-                    "isList": true,
-                    "datafileSchema": "/openshift/namespace-1.yml"
-                },
-                {
-                    "name": "gcp_projects_v1",
-                    "type": "GcpProject_v1",
-                    "isList": true,
-                    "datafileSchema": "/dependencies/gcp-project-1.yml"
-                },
-                {
-                    "name": "quay_orgs_v1",
-                    "type": "QuayOrg_v1",
-                    "isList": true,
-                    "datafileSchema": "/dependencies/quay-org-1.yml"
-                },
-                {
-                    "name": "quay_instances_v1",
-                    "type": "QuayInstance_v1",
-                    "isList": true,
-                    "datafileSchema": "/dependencies/quay-instance-1.yml"
-                },
-                {
-                    "name": "jenkins_instances_v1",
-                    "type": "JenkinsInstance_v1",
-                    "isList": true,
-                    "datafileSchema": "/dependencies/jenkins-instance-1.yml"
-                },
-                {
-                    "name": "jenkins_configs_v1",
-                    "type": "JenkinsConfig_v1",
-                    "isList": true,
-                    "datafileSchema": "/dependencies/jenkins-config-1.yml"
-                },
-                {
-                    "name": "jira_servers_v1",
-                    "type": "JiraServer_v1",
-                    "isList": true,
-                    "datafileSchema": "/dependencies/jira-server-1.yml"
-                },
-                {
-                    "name": "jira_boards_v1",
-                    "type": "JiraBoard_v1",
-                    "isList": true,
-                    "datafileSchema": "/dependencies/jira-board-1.yml"
-                },
-                {
-                    "name": "sendgrid_accounts_v1",
-                    "type": "SendGridAccount_v1",
-                    "isList": true,
-                    "datafileSchema": "/dependencies/sendgrid-account-1.yml"
-                },
-                {
-                    "name": "products_v1",
-                    "type": "Product_v1",
-                    "isList": true,
-                    "datafileSchema": "/app-sre/product-1.yml"
-                },
-                {
-                    "name": "environments_v1",
-                    "type": "Environment_v1",
-                    "isList": true,
-                    "datafileSchema": "/app-sre/environment-1.yml"
-                },
-                {
-                    "name": "apps_v1",
-                    "type": "App_v1",
-                    "isList": true,
-                    "datafileSchema": "/app-sre/app-1.yml"
-                },
-                {
-                    "name": "escalation_policies_1",
-                    "type": "AppEscalationPolicy_v1",
-                    "isList": true,
-                    "datafileSchema": "/app-sre/escalation-policy-1.yml"
-                },
-                {
-                    "name": "resources_v1",
-                    "type": "Resource_v1",
-                    "isResource": true,
-                    "isRequired": true,
-                    "isList": true
-                },
-                {
-                    "name": "vault_instances_v1",
-                    "type": "VaultInstance_v1",
-                    "isList": true,
-                    "datafileSchema": "/vault-config/instance-1.yml"
-                },
-                {
-                    "name": "vault_audit_backends_v1",
-                    "type": "VaultAudit_v1",
-                    "isList": true,
-                    "datafileSchema": "/vault-config/audit-1.yml"
-                },
-                {
-                    "name": "vault_auth_backends_v1",
-                    "type": "VaultAuth_v1",
-                    "isList": true,
-                    "datafileSchema": "/vault-config/auth-1.yml"
-                },
-                {
-                    "name": "vault_secret_engines_v1",
-                    "type": "VaultSecretEngine_v1",
-                    "isList": true,
-                    "datafileSchema": "/vault-config/secret-engine-1.yml"
-                },
-                {
-                    "name": "vault_roles_v1",
-                    "type": "VaultRole_v1",
-                    "isList": true,
-                    "datafileSchema": "/vault-config/role-1.yml"
-                },
-                {
-                    "name": "vault_policies_v1",
-                    "type": "VaultPolicy_v1",
-                    "isList": true,
-                    "datafileSchema": "/vault-config/policy-1.yml"
-                },
-                {
-                    "name": "dependencies_v1",
-                    "type": "Dependency_v1",
-                    "isList": true,
-                    "datafileSchema": "/dependencies/dependency-1.yml"
-                },
-                {
-                    "name": "githuborg_v1",
-                    "type": "GithubOrg_v1",
-                    "isList": true,
-                    "datafileSchema": "/dependencies/github-org-1.yml"
-                },
-                {
-                    "name": "gitlabinstance_v1",
-                    "type": "GitlabInstance_v1",
-                    "isList": true,
-                    "datafileSchema": "/dependencies/gitlab-instance-1.yml"
-                },
-                {
-                    "name": "integrations_v1",
-                    "type": "Integration_v1",
-                    "isList": true,
-                    "datafileSchema": "/app-sre/integration-1.yml"
-                },
-                {
-                    "name": "documents_v1",
-                    "type": "Document_v1",
-                    "isList": true,
-                    "datafileSchema": "/app-sre/document-1.yml"
-                },
-                {
-                    "name": "reports_v1",
-                    "type": "Report_v1",
-                    "isList": true,
-                    "datafileSchema": "/app-sre/report-1.yml"
-                },
-                {
-                    "name": "sre_checkpoints_v1",
-                    "type": "SRECheckpoint_v1",
-                    "isList": true,
-                    "datafileSchema": "/app-sre/sre-checkpoint-1.yml"
-                },
-                {
-                    "name": "sentry_teams_v1",
-                    "type": "SentryTeam_v1",
-                    "isList": true,
-                    "datafileSchema": "/dependencies/sentry-team-1.yml"
-                },
-                {
-                    "name": "sentry_instances_v1",
-                    "type": "SentryInstance_v1",
-                    "isList": true,
-                    "datafileSchema": "/dependencies/sentry-instance-1.yml"
-                },
-                {
-                    "name": "app_interface_sql_queries_v1",
-                    "type": "AppInterfaceSqlQuery_v1",
-                    "isList": true,
-                    "datafileSchema": "/app-interface/app-interface-sql-query-1.yml"
-                },
-                {
-                    "name": "saas_files_v2",
-                    "type": "SaasFile_v2",
-                    "isList": true,
-                    "datafileSchema": "/app-sre/saas-file-2.yml"
-                },
-                {
-                    "name": "pipelines_providers_v1",
-                    "type": "PipelinesProvider_v1",
-                    "isList": true,
-                    "isInterface": true,
-                    "datafileSchema": "/app-sre/pipelines-provider-1.yml"
-                },
-                {
-                    "name": "unleash_instances_v1",
-                    "type": "UnleashInstance_v1",
-                    "isList": true,
-                    "datafileSchema": "/app-sre/unleash-instance-1.yml"
-                },
-                {
-                    "name": "gabi_instances_v1",
-                    "type": "GabiInstance_v1",
-                    "isList": true,
-                    "datafileSchema": "/app-sre/gabi-instance-1.yml"
-                },
-                {
-                    "name": "template_tests_v1",
-                    "type": "TemplateTest_v1",
-                    "isList": true,
-                    "datafileSchema": "/app-interface/template-test-1.yml"
-                },
-                {
-                    "name": "dns_zone_v1",
-                    "type": "DnsZone_v1",
-                    "isList": true,
-                    "datafileSchema": "/dependencies/dns-zone-1.yml"
-                },
-                {
-                    "name": "slack_workspaces_v1",
-                    "type": "SlackWorkspace_v1",
-                    "isList": true,
-                    "datafileSchema": "/dependencies/slack-workspace-1.yml"
-                },
-                {
-                    "name": "ocp_release_mirror_v1",
-                    "type": "OcpReleaseMirror_v1",
-                    "isList": true,
-                    "datafileSchema": "/dependencies/ocp-release-mirror-1.yml"
-                },
-                {
-                    "name": "slo_document_v1",
-                    "type": "SLODocument_v1",
-                    "isList": true,
-                    "datafileSchema": "/app-sre/slo-document-1.yml"
-                },
-                {
-                    "name": "shared_resources_v1",
-                    "type": "SharedResources_v1",
-                    "isList": true,
-                    "datafileSchema": "/openshift/shared-resources-1.yml"
-                },
-                {
-                    "name": "pagerduty_instances_v1",
-                    "type": "PagerDutyInstance_v1",
-                    "isList": true,
-                    "datafileSchema": "/dependencies/pagerduty-instance-1.yml"
-                },
-                {
-                    "name": "ocm_instances_v1",
-                    "type": "OpenShiftClusterManager_v1",
-                    "isList": true,
-                    "datafileSchema": "/openshift/openshift-cluster-manager-1.yml"
-                },
-                {
-                    "name": "dyn_traffic_directors_v1",
-                    "type": "DynTrafficDirector_v1",
-                    "isList": true,
-                    "datafileSchema": "/dependencies/dyn-traffic-director-1.yml"
-                },
-                {
-                    "name": "status_page_v1",
-                    "type": "StatusPage_v1",
-                    "isList": true,
-                    "datafileSchema": "/dependencies/status-page-1.yml"
-                },
-                {
-                    "name": "status_page_component_v1",
-                    "type": "StatusPageComponent_v1",
-                    "isList": true,
-                    "datafileSchema": "/dependencies/status-page-component-1.yml"
-                },
-                {
-                    "name": "endpoint_monitoring_provider_v1",
-                    "type": "EndpointMonitoringProvider_v1",
-                    "isList": true,
-                    "isInterface": true,
-                    "datafileSchema": "/dependencies/endpoint-monitoring-provider-1.yml"
-                }
-            ]
-        },
-        {
-            "name": "SentryTeam_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "instance",
-                    "type": "SentryInstance_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "SentryRole_v1",
-            "fields": [
-                {
-                    "name": "role",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "instance",
-                    "type": "SentryInstance_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "SentryInstance_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "consoleUrl",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "automationToken",
-                    "type": "VaultSecret_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "adminUser",
-                    "type": "VaultSecret_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "SentryProjectItems_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "email_prefix",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "platform",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "sensitive_fields",
-                    "type": "string",
-                    "isRequired": false,
-                    "isList": true
-                },
-                {
-                    "name": "safe_fields",
-                    "type": "string",
-                    "isRequired": false,
-                    "isList": true
-                },
-                {
-                    "name": "auto_resolve_age",
-                    "type": "int",
-                    "isRequired": false
-                },
-                {
-                    "name": "allowed_domains",
-                    "type": "string",
-                    "isRequired": false,
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "AppSentryProjects_v1",
-            "fields": [
-                {
-                    "name": "team",
-                    "type": "SentryTeam_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "projects",
-                    "type": "SentryProjectItems_v1",
-                    "isRequired": true,
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "SqlEmailOverrides_v1",
-            "fields": [
-                {
-                    "name": "db_host",
-                    "type": "string"
-                },
-                {
-                    "name": "db_port",
-                    "type": "string"
-                },
-                {
-                    "name": "db_name",
-                    "type": "string"
-                },
-                {
-                    "name": "db_user",
-                    "type": "string"
-                },
-                {
-                    "name": "db_password",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "DnsNamespaceZone_v1",
-            "fields": [
-                {
-                    "name": "namespace",
-                    "type": "Namespace_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "DnsRecordHealthcheck_v1",
-            "fields": [
-                {
-                    "name": "fqdn",
-                    "type": "string"
-                },
-                {
-                    "name": "port",
-                    "type": "int"
-                },
-                {
-                    "name": "type",
-                    "type": "string"
-                },
-                {
-                    "name": "resource_path",
-                    "type": "string"
-                },
-                {
-                    "name": "failure_threshold",
-                    "type": "int"
-                },
-                {
-                    "name": "request_interval",
-                    "type": "int"
-                },
-                {
-                    "name": "search_string",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "DnsRecordWeightedRoutingPolicy_v1",
-            "fields": [
-                {
-                    "name": "weight",
-                    "type": "int"
-                }
-            ]
-        },
-        {
-            "name": "DnsRecordAlias_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "zone_id",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "evaluate_target_health",
-                    "type": "boolean",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "DnsRecord_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "type",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "ttl",
-                    "type": "int"
-                },
-                {
-                    "name": "alias",
-                    "type": "DnsRecordAlias_v1"
-                },
-                {
-                    "name": "weighted_routing_policy",
-                    "type": "DnsRecordWeightedRoutingPolicy_v1"
-                },
-                {
-                    "name": "set_identifier",
-                    "type": "string"
-                },
-                {
-                    "name": "records",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "_healthcheck",
-                    "type": "DnsRecordHealthcheck_v1"
-                },
-                {
-                    "name": "_target_cluster",
-                    "type": "Cluster_v1"
-                },
-                {
-                    "name": "_target_namespace_zone",
-                    "type": "DnsNamespaceZone_v1"
-                }
-            ]
-        },
-        {
-            "name": "DnsZone_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "account",
-                    "type": "AWSAccount_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "vpc",
-                    "type": "AWSVPC_v1"
-                },
-                {
-                    "name": "origin",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "unmanaged_record_names",
-                    "type": "string",
-                    "isList": true
-                },
-                {
-                    "name": "records",
-                    "type": "DnsRecord_v1",
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "SLODocumentSLOSLOParameters_v1",
-            "fields": [
-                {
-                    "name": "window",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "SLODocumentSLO_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "SLIType",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "SLISpecification",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "SLODetails",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "SLOTarget",
-                    "type": "float",
-                    "isRequired": true
-                },
-                {
-                    "name": "SLOParameters",
-                    "type": "SLODocumentSLOSLOParameters_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "expr",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "SLOTargetUnit",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "prometheusRules",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "prometheusRulesTests",
-                    "type": "string"
-                },
-                {
-                    "name": "dashboard",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "SLODocument_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "namespaces",
-                    "type": "Namespace_v1",
-                    "isList": true,
-                    "isRequired": true
-                },
-                {
-                    "name": "slos",
-                    "type": "SLODocumentSLO_v1",
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "DynTrafficDirectorRecord_v1",
-            "fields": [
-                {
-                    "name": "hostname",
-                    "type": "string"
-                },
-                {
-                    "name": "cluster",
-                    "type": "Cluster_v1"
-                },
-                {
-                    "name": "weight",
-                    "type": "int",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "DynTrafficDirector_v1",
-            "fields": [
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true,
-                    "isUnique": true
-                },
-                {
-                    "name": "ttl",
-                    "type": "int"
-                },
-                {
-                    "name": "records",
-                    "type": "DynTrafficDirectorRecord_v1",
-                    "isRequired": true,
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "StatusPage_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true,
-                    "isUnique": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "url",
-                    "type": "string"
-                },
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "apiUrl",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "credentials",
-                    "type": "VaultSecret_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "pageId",
-                    "type": "string",
-                    "isRequired": true,
-                    "isUnique": true
-                },
-                {
-                    "name": "components",
-                    "type": "StatusPageComponent_v1",
-                    "isList": true,
-                    "synthetic": {
-                        "schema": "/dependencies/status-page-component-1.yml",
-                        "subAttr": "page"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "StatusPageComponent_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true,
-                    "isUnique": true
-                },
-                {
-                    "name": "displayName",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "description",
-                    "type": "string"
-                },
-                {
-                    "name": "instructions",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "page",
-                    "type": "StatusPage_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "groupName",
-                    "type": "string"
-                },
-                {
-                    "name": "status",
-                    "type": "StatusProvider_v1",
-                    "isList": true,
-                    "isInterface": true
-                },
-                {
-                    "name": "apps",
-                    "type": "App_v1",
-                    "isList": true,
-                    "synthetic": {
-                        "schema": "/app-sre/app-1.yml",
-                        "subAttr": "statusPageComponents"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "EndpointMonitoringProvider_v1",
-            "isInterface": true,
-            "interfaceResolve": {
-                "strategy": "fieldMap",
-                "field": "provider",
-                "fieldMap": {
-                    "blackbox-exporter": "EndpointMonitoringProviderBlackboxExporter_v1",
-                    "signalfx": "EndpointMonitoringProviderSignalFx_v1"
-                }
+                ]
             },
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
+            {
+                "name": "VaultAuthConfig_v1",
+                "isInterface": true,
+                "interfaceResolve": {
+                    "strategy": "fieldMap",
+                    "field": "_type",
+                    "fieldMap": {
+                        "github": "VaultAuthConfigGithub_v1",
+                        "oidc": "VaultAuthConfigOidc_v1"
+                    }
                 },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true,
-                    "isUnique": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "metricLabels",
-                    "type": "json"
-                },
-                {
-                    "name": "timeout",
-                    "type": "string"
-                },
-                {
-                    "name": "checkInterval",
-                    "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "EndpointMonitoringProviderBlackboxExporter_v1",
-            "interface": "EndpointMonitoringProvider_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true,
-                    "isUnique": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "metricLabels",
-                    "type": "json"
-                },
-                {
-                    "name": "timeout",
-                    "type": "string"
-                },
-                {
-                    "name": "checkInterval",
-                    "type": "string"
-                },
-                {
-                    "name": "blackboxExporter",
-                    "type": "EndpointMonitoringProviderBlackboxExporterSettings_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "EndpointMonitoringProviderBlackboxExporterSettings_v1",
-            "fields": [
-                {
-                    "name": "module",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "namespace",
-                    "type": "Namespace_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "exporterUrl",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "EndpointMonitoringProviderSignalFx_v1",
-            "interface": "EndpointMonitoringProvider_v1",
-            "fields": [
-                {
-                    "name": "schema",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "path",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "labels",
-                    "type": "json"
-                },
-                {
-                    "name": "name",
-                    "type": "string",
-                    "isRequired": true,
-                    "isUnique": true
-                },
-                {
-                    "name": "description",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "metricLabels",
-                    "type": "json"
-                },
-                {
-                    "name": "timeout",
-                    "type": "string"
-                },
-                {
-                    "name": "checkInterval",
-                    "type": "string"
-                },
-                {
-                    "name": "signalFx",
-                    "type": "EndpointMonitoringProviderSignalFxSettings_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "EndpointMonitoringProviderSignalFxSettings_v1",
-            "fields": [
-                {
-                    "name": "namespace",
-                    "type": "Namespace_v1",
-                    "isRequired": true
-                },
-                {
-                    "name": "exporterUrl",
-                    "type": "string",
-                    "isRequired": true
-                },
-                {
-                    "name": "targetFilterLabel",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "StatusProvider_v1",
-            "isInterface": true,
-            "interfaceResolve": {
-                "strategy": "fieldMap",
-                "field": "provider",
-                "fieldMap": {
-                    "prometheus-alerts": "PrometheusAlertsStatusProvider_v1",
-                    "manual": "ManualStatusProvider_v1"
-                }
+                "fields": [
+                    {
+                        "name": "_type",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
             },
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "PrometheusAlertsStatusProvider_v1",
-            "interface": "StatusProvider_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
+            {
+                "name": "VaultAuthConfigGithub_v1",
+                "interface": "VaultAuthConfig_v1",
+                "fields": [
+                    {
+                        "name": "_type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "organization",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "base_url",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "max_ttl",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "ttl",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "VaultAuthConfigOidc_v1",
+                "interface": "VaultAuthConfig_v1",
+                "fields": [
+                    {
+                        "name": "_type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "oidc_discovery_url",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "oidc_client_id",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "oidc_client_secret",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "oidc_client_secret_kv_version",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "default_role",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "VaultAuthSettings_v1",
+                "fields": [
+                    {
+                        "name": "config",
+                        "type": "VaultAuthConfig_v1",
+                        "isInterface": true,
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "VaultSecretEngineOptions_v1",
+                "isInterface": true,
+                "interfaceResolve": {
+                    "strategy": "fieldMap",
+                    "field": "_type",
+                    "fieldMap": {
+                        "kv": "VaultSecretEngineOptionsKV_v1"
+                    }
                 },
-                {
-                    "name": "prometheusAlerts",
-                    "type": "PrometheusAlertsStatusProviderConfig_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "PrometheusAlertsStatusProviderConfig_v1",
-            "fields": [
-                {
-                    "name": "namespace",
-                    "type": "Namespace_v1",
-                    "isList": true
+                "fields": [
+                    {
+                        "name": "_type",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "VaultSecretEngineOptionsKV_v1",
+                "interface": "VaultSecretEngineOptions_v1",
+                "fields": [
+                    {
+                        "name": "_type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "version",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "VaultSecretEngine_v1",
+                "fields": [
+                    {
+                        "name": "_path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "instance",
+                        "type": "VaultInstance_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "options",
+                        "type": "VaultSecretEngineOptions_v1",
+                        "isInterface": true
+                    }
+                ]
+            },
+            {
+                "name": "VaultRoleOptions_v1",
+                "isInterface": true,
+                "interfaceResolve": {
+                    "strategy": "fieldMap",
+                    "field": "_type",
+                    "fieldMap": {
+                        "approle": "VaultApproleOptions_v1",
+                        "oidc": "VaultRoleOidcOptions_v1"
+                    }
                 },
-                {
-                    "name": "matchers",
-                    "type": "PrometheusAlertMatcher_v1",
-                    "isList": true
-                }
-            ]
-        },
-        {
-            "name": "PrometheusAlertMatcher_v1",
-            "fields": [
-                {
-                    "name": "matchExpression",
-                    "type": "PrometheusAlertMatcherExpression_v1",
-                    "isRequired": true
+                "fields": [
+                    {
+                        "name": "_type",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "VaultApproleOptions_v1",
+                "interface": "VaultRoleOptions_v1",
+                "fields": [
+                    {
+                        "name": "_type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "bind_secret_id",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "local_secret_ids",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token_period",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "secret_id_num_uses",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "secret_id_ttl",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token_explicit_max_ttl",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token_max_ttl",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token_no_default_policy",
+                        "type": "boolean",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token_num_uses",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token_ttl",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token_type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token_policies",
+                        "type": "string",
+                        "isList": true,
+                        "isRequired": true
+                    },
+                    {
+                        "name": "policies",
+                        "type": "string",
+                        "isList": true,
+                        "isRequired": true
+                    },
+                    {
+                        "name": "secret_id_bound_cidrs",
+                        "type": "string",
+                        "isList": true,
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token_bound_cidrs",
+                        "type": "string",
+                        "isList": true,
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "VaultRoleOidcOptions_v1",
+                "interface": "VaultRoleOptions_v1",
+                "fields": [
+                    {
+                        "name": "_type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "allowed_redirect_uris",
+                        "type": "string",
+                        "isList": true,
+                        "isRequired": true
+                    },
+                    {
+                        "name": "bound_audiences",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "bound_claims",
+                        "type": "json"
+                    },
+                    {
+                        "name": "bound_claims_type",
+                        "type": "string"
+                    },
+                    {
+                        "name": "bound_subject",
+                        "type": "string"
+                    },
+                    {
+                        "name": "claim_mappings",
+                        "type": "json"
+                    },
+                    {
+                        "name": "clock_skew_leeway",
+                        "type": "string"
+                    },
+                    {
+                        "name": "expiration_leeway",
+                        "type": "string"
+                    },
+                    {
+                        "name": "groups_claim",
+                        "type": "string"
+                    },
+                    {
+                        "name": "max_age",
+                        "type": "string"
+                    },
+                    {
+                        "name": "not_before_leeway",
+                        "type": "string"
+                    },
+                    {
+                        "name": "oidc_scopes",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "role_type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token_ttl",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token_max_ttl",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token_explicit_max_ttl",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token_type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token_period",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token_policies",
+                        "type": "string",
+                        "isList": true,
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token_bound_cidrs",
+                        "type": "string",
+                        "isList": true,
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token_no_default_policy",
+                        "type": "boolean",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token_num_uses",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "user_claim",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "verbose_oidc_logging",
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "VaultRole_v1",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "mount",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "instance",
+                        "type": "VaultInstance_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "options",
+                        "type": "VaultRoleOptions_v1",
+                        "isInterface": true,
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "VaultPolicy_v1",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "instance",
+                        "type": "VaultInstance_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "rules",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "Resource_v1",
+                "fields": [
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "content",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "sha256sum",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "schema",
+                        "type": "string"
+                    },
+                    {
+                        "name": "backrefs",
+                        "type": "ResourceBackref_v1",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "ResourceBackref_v1",
+                "fields": [
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "datafileSchema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "jsonpath",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "VaultSecret_v1",
+                "fields": [
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "field",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "format",
+                        "type": "string"
+                    },
+                    {
+                        "name": "version",
+                        "type": "int"
+                    }
+                ]
+            },
+            {
+                "name": "KeyValue_v1",
+                "fields": [
+                    {
+                        "name": "key",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "value",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "ClusterJumpHost_v1",
+                "fields": [
+                    {
+                        "name": "hostname",
+                        "type": "string",
+                        "isRequired": true,
+                        "isUnique": true,
+                        "isSearchable": true
+                    },
+                    {
+                        "name": "knownHosts",
+                        "type": "string",
+                        "isRequired": true,
+                        "isResource": true
+                    },
+                    {
+                        "name": "user",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "port",
+                        "type": "int"
+                    },
+                    {
+                        "name": "identity",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "clusters",
+                        "type": "Cluster_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/openshift/cluster-1.yml",
+                            "subAttr": "jumpHost"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "DisableClusterAutomations_v1",
+                "fields": [
+                    {
+                        "name": "integrations",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "e2eTests",
+                        "type": "string",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "GcpProject_v1",
+                "interface": "ExternalResourcesProvisioner_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "managedTeams",
+                        "type": "string",
+                        "isList": true,
+                        "isRequired": true
+                    },
+                    {
+                        "name": "automationToken",
+                        "type": "VaultSecret_v1"
+                    },
+                    {
+                        "name": "pushCredentials",
+                        "type": "VaultSecret_v1"
+                    }
+                ]
+            },
+            {
+                "name": "GrafanaDashboardUrls_v1",
+                "fields": [
+                    {
+                        "name": "title",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "url",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "QuayOrg_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "mirror",
+                        "type": "QuayOrg_v1"
+                    },
+                    {
+                        "name": "managedRepos",
+                        "type": "boolean",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "instance",
+                        "type": "QuayInstance_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "serverUrl",
+                        "type": "string"
+                    },
+                    {
+                        "name": "managedTeams",
+                        "type": "string",
+                        "isList": true,
+                        "isRequired": true
+                    },
+                    {
+                        "name": "automationToken",
+                        "type": "VaultSecret_v1"
+                    },
+                    {
+                        "name": "pushCredentials",
+                        "type": "VaultSecret_v1"
+                    }
+                ]
+            },
+            {
+                "name": "QuayInstance_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "url",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "JenkinsInstanceBuildsCleanupRules_v1",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "keep_hours",
+                        "type": "int",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "JenkinsInstance_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "serverUrl",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "previousUrls",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "plugins",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "deleteMethod",
+                        "type": "string"
+                    },
+                    {
+                        "name": "managedProjects",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "buildsCleanupRules",
+                        "type": "JenkinsInstanceBuildsCleanupRules_v1",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "JenkinsConfig_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "app",
+                        "type": "App_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "instance",
+                        "type": "JenkinsInstance_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "config",
+                        "type": "json"
+                    },
+                    {
+                        "name": "config_path",
+                        "type": "string",
+                        "isResource": true,
+                        "resolveResource": true
+                    }
+                ]
+            },
+            {
+                "name": "JiraServer_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "serverUrl",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "SeverityPriorityMapping_v1",
+                "fields": [
+                    {
+                        "name": "severity",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "priority",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "JiraSeverityPriorityMappings_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "mappings",
+                        "type": "SeverityPriorityMapping_v1",
+                        "isList": true,
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "JiraBoard_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true,
+                        "isUnique": true,
+                        "isSearchable": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "server",
+                        "type": "JiraServer_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "severityPriorityMappings",
+                        "type": "JiraSeverityPriorityMappings_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "slack",
+                        "type": "SlackOutput_v1"
+                    },
+                    {
+                        "name": "issueResolveState",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "SendGridAccount_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true,
+                        "isUnique": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "SlackWorkspace_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "api_client",
+                        "type": "SlackWorkspaceApiClient_v1"
+                    },
+                    {
+                        "name": "integrations",
+                        "type": "SlackWorkspaceIntegration_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "managedUsergroups",
+                        "type": "string",
+                        "isList": true,
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "SlackWorkspaceApiClient_v1",
+                "fields": [
+                    {
+                        "name": "global",
+                        "type": "SlackWorkspaceApiClientGlobalConfig_v1"
+                    },
+                    {
+                        "name": "methods",
+                        "type": "SlackWorkspaceApiClientMethodConfig_v1",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "SlackWorkspaceApiClientGlobalConfig_v1",
+                "fields": [
+                    {
+                        "name": "max_retries",
+                        "type": "int"
+                    },
+                    {
+                        "name": "timeout",
+                        "type": "int"
+                    }
+                ]
+            },
+            {
+                "name": "SlackWorkspaceApiClientMethodConfig_v1",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "args",
+                        "type": "json",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "SlackWorkspaceIntegration_v1",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "channel",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "icon_emoji",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "username",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "GithubOrg_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "url",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "two_factor_authentication",
+                        "type": "boolean",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "default",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "token",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "managedTeams",
+                        "type": "string",
+                        "isList": true,
+                        "isRequired": false
+                    }
+                ]
+            },
+            {
+                "name": "GitlabProjects_v1",
+                "fields": [
+                    {
+                        "name": "group",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "projects",
+                        "type": "string",
+                        "isList": true,
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "GitlabInstance_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "backupOrgs",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "managedGroups",
+                        "type": "string",
+                        "isList": true,
+                        "isRequired": true
+                    },
+                    {
+                        "name": "projectRequests",
+                        "type": "GitlabProjects_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "url",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "sslVerify",
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "PagerDutyInstance_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "PagerDutyTarget_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "instance",
+                        "type": "PagerDutyInstance_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "scheduleID",
+                        "type": "string"
+                    },
+                    {
+                        "name": "escalationPolicyID",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "ClusterAuth_v1",
+                "isInterface": true,
+                "interfaceResolve": {
+                    "strategy": "fieldMap",
+                    "field": "service",
+                    "fieldMap": {
+                        "github-org": "ClusterAuthGithubOrg_v1",
+                        "github-org-team": "ClusterAuthGithubOrgTeam_v1",
+                        "oidc": "ClusterAuthOIDC_v1"
+                    }
                 },
-                {
-                    "name": "componentStatus",
-                    "type": "string",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "PrometheusAlertMatcherExpression_v1",
-            "fields": [
-                {
-                    "name": "alert",
-                    "type": "string"
+                "fields": [
+                    {
+                        "name": "service",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "ClusterAuthGithubOrg_v1",
+                "interface": "ClusterAuth_v1",
+                "fields": [
+                    {
+                        "name": "service",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "org",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "ClusterAuthGithubOrgTeam_v1",
+                "interface": "ClusterAuth_v1",
+                "fields": [
+                    {
+                        "name": "service",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "org",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "team",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "ClusterAuthOIDC_v1",
+                "interface": "ClusterAuth_v1",
+                "fields": [
+                    {
+                        "name": "service",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "KafkaClusterSpec_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "multi_az",
+                        "type": "boolean",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "ClusterSpec_v1",
+                "isInterface": true,
+                "interfaceResolve": {
+                    "strategy": "fieldMap",
+                    "field": "product",
+                    "fieldMap": {
+                        "osd": "ClusterSpecOSD_v1",
+                        "rosa": "ClusterSpecROSA_v1"
+                    }
                 },
-                {
-                    "name": "labels",
-                    "type": "json"
-                }
-            ]
-        },
-        {
-            "name": "ManualStatusProvider_v1",
-            "interface": "StatusProvider_v1",
-            "fields": [
-                {
-                    "name": "provider",
-                    "type": "string",
-                    "isRequired": true
+                "fields": [
+                    {
+                        "name": "product",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "id",
+                        "type": "string"
+                    },
+                    {
+                        "name": "external_id",
+                        "type": "string"
+                    },
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "channel",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "version",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "initial_version",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "multi_az",
+                        "type": "boolean",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "nodes",
+                        "type": "int"
+                    },
+                    {
+                        "name": "instance_type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "private",
+                        "type": "boolean",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "provision_shard_id",
+                        "type": "string"
+                    },
+                    {
+                        "name": "autoscale",
+                        "type": "ClusterSpecAutoScale_v1"
+                    },
+                    {
+                        "name": "disable_user_workload_monitoring",
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "ClusterSpecOSD_v1",
+                "interface": "ClusterSpec_v1",
+                "fields": [
+                    {
+                        "name": "product",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "id",
+                        "type": "string"
+                    },
+                    {
+                        "name": "external_id",
+                        "type": "string"
+                    },
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "channel",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "version",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "initial_version",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "multi_az",
+                        "type": "boolean",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "nodes",
+                        "type": "int"
+                    },
+                    {
+                        "name": "instance_type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "private",
+                        "type": "boolean",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "provision_shard_id",
+                        "type": "string"
+                    },
+                    {
+                        "name": "autoscale",
+                        "type": "ClusterSpecAutoScale_v1"
+                    },
+                    {
+                        "name": "disable_user_workload_monitoring",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "storage",
+                        "type": "int",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "load_balancers",
+                        "type": "int",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "ClusterSpecROSA_v1",
+                "interface": "ClusterSpec_v1",
+                "fields": [
+                    {
+                        "name": "product",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "id",
+                        "type": "string"
+                    },
+                    {
+                        "name": "external_id",
+                        "type": "string"
+                    },
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "channel",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "version",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "initial_version",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "multi_az",
+                        "type": "boolean",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "nodes",
+                        "type": "int"
+                    },
+                    {
+                        "name": "instance_type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "private",
+                        "type": "boolean",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "provision_shard_id",
+                        "type": "string"
+                    },
+                    {
+                        "name": "autoscale",
+                        "type": "ClusterSpecAutoScale_v1"
+                    },
+                    {
+                        "name": "disable_user_workload_monitoring",
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "ClusterSpecAutoScale_v1",
+                "fields": [
+                    {
+                        "name": "min_replicas",
+                        "type": "int",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "max_replicas",
+                        "type": "int",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "ClusterExternalConfiguration_v1",
+                "fields": [
+                    {
+                        "name": "labels",
+                        "type": "json",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "ClusterAdditionalRouter_v1",
+                "fields": [
+                    {
+                        "name": "private",
+                        "type": "boolean",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "route_selectors",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "ClusterUpgradePolicyConditions_v1",
+                "fields": [
+                    {
+                        "name": "soakDays",
+                        "type": "int"
+                    },
+                    {
+                        "name": "mutexes",
+                        "type": "string",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "ClusterUpgradePolicy_v1",
+                "fields": [
+                    {
+                        "name": "schedule_type",
+                        "type": "string"
+                    },
+                    {
+                        "name": "schedule",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "workloads",
+                        "type": "string",
+                        "isList": true,
+                        "isRequired": true
+                    },
+                    {
+                        "name": "conditions",
+                        "type": "ClusterUpgradePolicyConditions_v1",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "ClusterNetwork_v1",
+                "fields": [
+                    {
+                        "name": "type",
+                        "type": "string"
+                    },
+                    {
+                        "name": "vpc",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "service",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "pod",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "ClusterMachinePool_v1",
+                "fields": [
+                    {
+                        "name": "id",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "instance_type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "replicas",
+                        "type": "int",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "taints",
+                        "type": "Taint_v1",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "Taint_v1",
+                "fields": [
+                    {
+                        "name": "key",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "value",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "effect",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "ClusterPeeringConnection_v1",
+                "isInterface": true,
+                "interfaceResolve": {
+                    "strategy": "fieldMap",
+                    "field": "provider",
+                    "fieldMap": {
+                        "account-vpc": "ClusterPeeringConnectionAccount_v1",
+                        "account-vpc-mesh": "ClusterPeeringConnectionAccountVPCMesh_v1",
+                        "account-tgw": "ClusterPeeringConnectionAccountTGW_v1",
+                        "cluster-vpc-requester": "ClusterPeeringConnectionClusterRequester_v1",
+                        "cluster-vpc-accepter": "ClusterPeeringConnectionClusterAccepter_v1"
+                    }
                 },
-                {
-                    "name": "manual",
-                    "type": "ManualStatusProviderConfig_v1",
-                    "isRequired": true
-                }
-            ]
-        },
-        {
-            "name": "ManualStatusProviderConfig_v1",
-            "fields": [
-                {
-                    "name": "componentStatus",
-                    "type": "string",
-                    "isRequired": true
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string"
+                    },
+                    {
+                        "name": "manageRoutes",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "delete",
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "ClusterPeeringConnectionAccount_v1",
+                "interface": "ClusterPeeringConnection_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "vpc",
+                        "type": "AWSVPC_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string"
+                    },
+                    {
+                        "name": "manageRoutes",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "delete",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "assumeRole",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "ClusterPeeringConnectionAccountVPCMesh_v1",
+                "interface": "ClusterPeeringConnection_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "account",
+                        "type": "AWSAccount_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string"
+                    },
+                    {
+                        "name": "tags",
+                        "type": "json"
+                    },
+                    {
+                        "name": "manageRoutes",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "delete",
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "ClusterPeeringConnectionAccountTGW_v1",
+                "interface": "ClusterPeeringConnection_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "account",
+                        "type": "AWSAccount_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string"
+                    },
+                    {
+                        "name": "tags",
+                        "type": "json"
+                    },
+                    {
+                        "name": "manageRoutes",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "manageSecurityGroups",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "cidrBlock",
+                        "type": "string"
+                    },
+                    {
+                        "name": "delete",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "assumeRole",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "ClusterPeeringConnectionClusterRequester_v1",
+                "interface": "ClusterPeeringConnection_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "cluster",
+                        "type": "Cluster_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string"
+                    },
+                    {
+                        "name": "manageRoutes",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "delete",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "assumeRole",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "ClusterPeeringConnectionClusterAccepter_v1",
+                "interface": "ClusterPeeringConnection_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "cluster",
+                        "type": "Cluster_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "awsInfrastructureManagementAccount",
+                        "type": "AWSAccount_v1"
+                    },
+                    {
+                        "name": "description",
+                        "type": "string"
+                    },
+                    {
+                        "name": "manageRoutes",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "delete",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "assumeRole",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "ClusterPeering_v1",
+                "fields": [
+                    {
+                        "name": "connections",
+                        "type": "ClusterPeeringConnection_v1",
+                        "isRequired": true,
+                        "isList": true,
+                        "isInterface": true
+                    }
+                ]
+            },
+            {
+                "name": "ClusterPrometheus_v1",
+                "fields": [
+                    {
+                        "name": "url",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "auth",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "Cluster_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isUnique": true,
+                        "isSearchable": true,
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string"
+                    },
+                    {
+                        "name": "auth",
+                        "type": "ClusterAuth_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "observabilityNamespace",
+                        "type": "Namespace_v1"
+                    },
+                    {
+                        "name": "grafanaUrl",
+                        "type": "string"
+                    },
+                    {
+                        "name": "consoleUrl",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "kibanaUrl",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "prometheusUrl",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "alertmanagerUrl",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "serverUrl",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "elbFQDN",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "managedGroups",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "managedClusterRoles",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "ocm",
+                        "type": "OpenShiftClusterManager_v1"
+                    },
+                    {
+                        "name": "spec",
+                        "type": "ClusterSpec_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "externalConfiguration",
+                        "type": "ClusterExternalConfiguration_v1"
+                    },
+                    {
+                        "name": "upgradePolicy",
+                        "type": "ClusterUpgradePolicy_v1"
+                    },
+                    {
+                        "name": "additionalRouters",
+                        "type": "ClusterAdditionalRouter_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "network",
+                        "type": "ClusterNetwork_v1"
+                    },
+                    {
+                        "name": "machinePools",
+                        "type": "ClusterMachinePool_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "peering",
+                        "type": "ClusterPeering_v1"
+                    },
+                    {
+                        "name": "addons",
+                        "type": "ClusterAddon_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "insecureSkipTLSVerify",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "jumpHost",
+                        "type": "ClusterJumpHost_v1"
+                    },
+                    {
+                        "name": "automationToken",
+                        "type": "VaultSecret_v1"
+                    },
+                    {
+                        "name": "clusterAdminAutomationToken",
+                        "type": "VaultSecret_v1"
+                    },
+                    {
+                        "name": "internal",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "disable",
+                        "type": "DisableClusterAutomations_v1"
+                    },
+                    {
+                        "name": "awsInfrastructureAccess",
+                        "type": "AWSInfrastructureAccess_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "awsInfrastructureManagementAccounts",
+                        "type": "AWSInfrastructureManagementAccount_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "prometheus",
+                        "type": "ClusterPrometheus_v1"
+                    },
+                    {
+                        "name": "namespaces",
+                        "type": "Namespace_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/openshift/namespace-1.yml",
+                            "subAttr": "cluster"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "KafkaCluster_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string"
+                    },
+                    {
+                        "name": "ocm",
+                        "type": "OpenShiftClusterManager_v1"
+                    },
+                    {
+                        "name": "spec",
+                        "type": "KafkaClusterSpec_v1"
+                    },
+                    {
+                        "name": "namespaces",
+                        "type": "Namespace_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/openshift/namespace-1.yml",
+                            "subAttr": "kafkaCluster"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "OpenShiftClusterManager_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string"
+                    },
+                    {
+                        "name": "url",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "accessTokenClientId",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "accessTokenUrl",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "offlineToken",
+                        "type": "VaultSecret_v1"
+                    },
+                    {
+                        "name": "blockedVersions",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "clusters",
+                        "type": "Cluster_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/openshift/cluster-1.yml",
+                            "subAttr": "cluster"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "ClusterAddon_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string"
+                    },
+                    {
+                        "name": "parameters",
+                        "type": "ClusterAddonParameters_v1",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "ClusterAddonParameters_v1",
+                "fields": [
+                    {
+                        "name": "id",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "value",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "AWSInfrastructureAccess_v1",
+                "fields": [
+                    {
+                        "name": "awsGroup",
+                        "type": "AWSGroup_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "accessLevel",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "AWSInfrastructureManagementAccount_v1",
+                "fields": [
+                    {
+                        "name": "account",
+                        "type": "AWSAccount_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "accessLevel",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "default",
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "ExternalResourcesProvisioner_v1",
+                "isInterface": true,
+                "interfaceResolve": {
+                    "strategy": "fieldMap",
+                    "fieldMap": {}
                 },
-                {
-                    "name": "from",
-                    "type": "string"
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "AWSAccount_v1",
+                "interface": "ExternalResourcesProvisioner_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true,
+                        "isUnique": true,
+                        "isSearchable": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string"
+                    },
+                    {
+                        "name": "consoleUrl",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "uid",
+                        "type": "string",
+                        "isRequired": true,
+                        "isSearchable": true
+                    },
+                    {
+                        "name": "resourcesDefaultRegion",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "supportedDeploymentRegions",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "providerVersion",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "terraformUsername",
+                        "type": "string"
+                    },
+                    {
+                        "name": "accountOwners",
+                        "type": "Owner_v1",
+                        "isList": true,
+                        "isRequired": true
+                    },
+                    {
+                        "name": "automationToken",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "garbageCollection",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "enableDeletion",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "deletionApprovals",
+                        "type": "AWSAccountDeletionApproval_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "disable",
+                        "type": "DisableClusterAutomations_v1"
+                    },
+                    {
+                        "name": "deleteKeys",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "resetPasswords",
+                        "type": "AWSAccountResetPassword_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "premiumSupport",
+                        "type": "boolean",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "partition",
+                        "type": "string"
+                    },
+                    {
+                        "name": "sharing",
+                        "type": "AWSAccountSharingOption_v1",
+                        "isList": true,
+                        "isInterface": true
+                    },
+                    {
+                        "name": "terraformState",
+                        "type": "TerraformStateAWS_v1",
+                        "isRequired": false
+                    },
+                    {
+                        "name": "ecrs",
+                        "type": "AWSECR_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/aws/ecr-1.yml",
+                            "subAttr": "account"
+                        }
+                    },
+                    {
+                        "name": "policies",
+                        "type": "AWSUserPolicy_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/aws/policy-1.yml",
+                            "subAttr": "account"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "AWSGroup_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "account",
+                        "type": "AWSAccount_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string"
+                    },
+                    {
+                        "name": "policies",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "roles",
+                        "type": "Role_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/access/role-1.yml",
+                            "subAttr": "aws_groups"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "AWSAccountDeletionApproval_v1",
+                "fields": [
+                    {
+                        "name": "type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "expiration",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "AWSAccountResetPassword_v1",
+                "fields": [
+                    {
+                        "name": "user",
+                        "type": "User_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "requestId",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "AWSAccountSharingOption_v1",
+                "isInterface": true,
+                "interfaceResolve": {
+                    "strategy": "fieldMap",
+                    "field": "provider",
+                    "fieldMap": {
+                        "ami": "AWSAccountSharingOptionAMI_v1"
+                    }
                 },
-                {
-                    "name": "until",
-                    "type": "string"
-                }
-            ]
-        }
-    ],
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "account",
+                        "type": "AWSAccount_v1",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "AWSAccountSharingOptionAMI_v1",
+                "interface": "AWSAccountSharingOption_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "account",
+                        "type": "AWSAccount_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "regex",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "AWSUserPolicy_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "account",
+                        "type": "AWSAccount_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string"
+                    },
+                    {
+                        "name": "mandatory",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "policy",
+                        "type": "json",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "AWSVPC_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "account",
+                        "type": "AWSAccount_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string"
+                    },
+                    {
+                        "name": "vpc_id",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "cidr_block",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "subnets",
+                        "type": "AWSSubnet_v1",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "AWSSubnet_v1",
+                "fields": [
+                    {
+                        "name": "id",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "AWSECR_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "account",
+                        "type": "AWSAccount_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string"
+                    },
+                    {
+                        "name": "region",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "AWSS3EventNotification_v1",
+                "fields": [
+                    {
+                        "name": "event_type",
+                        "type": "string",
+                        "isRequired": true,
+                        "isList": true
+                    },
+                    {
+                        "name": "destination",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "destination_type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "filter_prefix",
+                        "type": "string"
+                    },
+                    {
+                        "name": "filter_suffix",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "AWSRDSEventNotification_v1",
+                "fields": [
+                    {
+                        "name": "destination",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "source_type",
+                        "type": "string"
+                    },
+                    {
+                        "name": "event_categories",
+                        "type": "string",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "TerraformState_v1",
+                "isInterface": true,
+                "interfaceResolve": {
+                    "strategy": "fieldMap",
+                    "field": "provider",
+                    "fieldMap": {
+                        "s3": "TerraformStateAWS_v1"
+                    }
+                },
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": false
+                    }
+                ]
+            },
+            {
+                "name": "TerraformStateAWS_v1",
+                "interface": "TerraformState_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "bucket",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "integrations",
+                        "type": "AWSTerraformStateIntegrations_v1",
+                        "isList": true,
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "AWSTerraformStateIntegrations_v1",
+                "fields": [
+                    {
+                        "name": "integration",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "key",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "ACMDomain_v1",
+                "fields": [
+                    {
+                        "name": "domain_name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "alternate_names",
+                        "type": "string",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceOpenshiftResource_v1",
+                "datafile": "/openshift/openshift-resource-1.yml",
+                "isInterface": true,
+                "interfaceResolve": {
+                    "strategy": "fieldMap",
+                    "field": "provider",
+                    "fieldMap": {
+                        "resource": "NamespaceOpenshiftResourceResource_v1",
+                        "resource-template": "NamespaceOpenshiftResourceResourceTemplate_v1",
+                        "vault-secret": "NamespaceOpenshiftResourceVaultSecret_v1",
+                        "route": "NamespaceOpenshiftResourceRoute_v1"
+                    }
+                },
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceOpenshiftResourceResource_v1",
+                "interface": "NamespaceOpenshiftResource_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true,
+                        "isResource": true
+                    },
+                    {
+                        "name": "validate_json",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "validate_alertmanager_config",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "alertmanager_config_key",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceOpenshiftResourceResourceTemplate_v1",
+                "interface": "NamespaceOpenshiftResource_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true,
+                        "isResource": true
+                    },
+                    {
+                        "name": "type",
+                        "type": "string"
+                    },
+                    {
+                        "name": "variables",
+                        "type": "json"
+                    },
+                    {
+                        "name": "validate_alertmanager_config",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "alertmanager_config_key",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceOpenshiftResourceVaultSecret_v1",
+                "interface": "NamespaceOpenshiftResource_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "version",
+                        "type": "int",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    },
+                    {
+                        "name": "type",
+                        "type": "string"
+                    },
+                    {
+                        "name": "validate_alertmanager_config",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "alertmanager_config_key",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceOpenshiftResourceRoute_v1",
+                "interface": "NamespaceOpenshiftResource_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true,
+                        "isResource": true
+                    },
+                    {
+                        "name": "vault_tls_secret_path",
+                        "type": "string"
+                    },
+                    {
+                        "name": "vault_tls_secret_version",
+                        "type": "int"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceExternalResource_v1",
+                "isInterface": true,
+                "interfaceResolve": {
+                    "strategy": "fieldMap",
+                    "field": "provider",
+                    "fieldMap": {
+                        "aws": "NamespaceTerraformProviderResourceAWS_v1",
+                        "gcp-project": "NamespaceTerraformProviderResourceGCPProject_v1"
+                    }
+                },
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "provisioner",
+                        "type": "ExternalResourcesProvisioner_v1",
+                        "isRequired": true,
+                        "isInterface": true
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformProviderResourceAWS_v1",
+                "interface": "NamespaceExternalResource_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "provisioner",
+                        "type": "AWSAccount_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "resources",
+                        "type": "NamespaceTerraformResourceAWS_v1",
+                        "isRequired": true,
+                        "isList": true,
+                        "isInterface": true
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformProviderResourceGCPProject_v1",
+                "interface": "NamespaceExternalResource_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "provisioner",
+                        "type": "GcpProject_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "resources",
+                        "type": "NamespaceTerraformResourceGCP_v1",
+                        "isRequired": true,
+                        "isList": true,
+                        "isInterface": true
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceGCP_v1",
+                "datafile": "/gcp/terraform-resource-1.yml",
+                "isInterface": true,
+                "interfaceResolve": {
+                    "strategy": "fieldMap",
+                    "field": "provider",
+                    "fieldMap": {
+                        "dns-zone": "NamespaceTerraformResourceManagedZone_v1"
+                    }
+                },
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceManagedZone_v1",
+                "interface": "NamespaceTerraformResourceGCP_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceAWS_v1",
+                "datafile": "/aws/terraform-resources-1.yml",
+                "isInterface": true,
+                "interfaceResolve": {
+                    "strategy": "fieldMap",
+                    "field": "provider",
+                    "fieldMap": {
+                        "rds": "NamespaceTerraformResourceRDS_v1",
+                        "s3": "NamespaceTerraformResourceS3_v1",
+                        "elasticache": "NamespaceTerraformResourceElastiCache_v1",
+                        "aws-iam-service-account": "NamespaceTerraformResourceServiceAccount_v1",
+                        "secrets-manager-service-account": "NamespaceTerraformResourceSecretsManagerServiceAccount_v1",
+                        "aws-iam-role": "NamespaceTerraformResourceRole_v1",
+                        "sqs": "NamespaceTerraformResourceSQS_v1",
+                        "sns": "NamespaceTerraformResourceSNSTopic_v1",
+                        "dynamodb": "NamespaceTerraformResourceDynamoDB_v1",
+                        "ecr": "NamespaceTerraformResourceECR_v1",
+                        "s3-cloudfront": "NamespaceTerraformResourceS3CloudFront_v1",
+                        "s3-sqs": "NamespaceTerraformResourceS3SQS_v1",
+                        "cloudwatch": "NamespaceTerraformResourceCloudWatch_v1",
+                        "kms": "NamespaceTerraformResourceKMS_v1",
+                        "elasticsearch": "NamespaceTerraformResourceElasticSearch_v1",
+                        "acm": "NamespaceTerraformResourceACM_v1",
+                        "kinesis": "NamespaceTerraformResourceKinesis_v1",
+                        "s3-cloudfront-public-key": "NamespaceTerraformResourceS3CloudFrontPublicKey_v1",
+                        "alb": "NamespaceTerraformResourceALB_v1",
+                        "secrets-manager": "NamespaceTerraformResourceSecretsManager_v1",
+                        "asg": "NamespaceTerraformResourceASG_v1",
+                        "route53-zone": "NamespaceTerraformResourceRoute53Zone_v1",
+                        "rosa-authenticator": "NamespaceTerraformResourceRosaAuthenticator_V1",
+                        "rosa-authenticator-vpce": "NamespaceTerraformResourceRosaAuthenticatorVPCE_V1"
+                    }
+                },
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceOutputFormat_v1",
+                "isInterface": true,
+                "interfaceResolve": {
+                    "strategy": "fieldMap",
+                    "field": "provider",
+                    "fieldMap": {
+                        "generic-secret": "NamespaceTerraformResourceGenericSecretOutputFormat_v1"
+                    }
+                },
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceGenericSecretOutputFormat_v1",
+                "interface": "NamespaceTerraformResourceOutputFormat_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "data",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceASG_v1",
+                "interface": "NamespaceTerraformResourceAWS_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string"
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "defaults",
+                        "type": "string",
+                        "isRequired": true,
+                        "isResource": true
+                    },
+                    {
+                        "name": "cloudinit_configs",
+                        "type": "CloudinitConfig_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "variables",
+                        "type": "json"
+                    },
+                    {
+                        "name": "image",
+                        "type": "ASGImage_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "CloudinitConfig_v1",
+                "fields": [
+                    {
+                        "name": "filename",
+                        "type": "string"
+                    },
+                    {
+                        "name": "content_type",
+                        "type": "string"
+                    },
+                    {
+                        "name": "content",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "ASGImage_v1",
+                "fields": [
+                    {
+                        "name": "tag_name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "url",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "ref",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "upstream",
+                        "type": "SaasResourceTemplateTargetUpstream_v1"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceSecretsManager_v1",
+                "interface": "NamespaceTerraformResourceAWS_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string"
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "secret",
+                        "type": "VaultSecret_v1"
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceS3CloudFrontPublicKey_v1",
+                "interface": "NamespaceTerraformResourceAWS_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string"
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "secret",
+                        "type": "VaultSecret_v1"
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceACM_v1",
+                "interface": "NamespaceTerraformResourceAWS_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string"
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "secret",
+                        "type": "VaultSecret_v1"
+                    },
+                    {
+                        "name": "domain",
+                        "type": "ACMDomain_v1"
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceElasticSearch_v1",
+                "interface": "NamespaceTerraformResourceAWS_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string"
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "defaults",
+                        "type": "string",
+                        "isRequired": true,
+                        "isResource": true
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    },
+                    {
+                        "name": "publish_log_types",
+                        "type": "string",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceRDS_v1",
+                "interface": "NamespaceTerraformResourceAWS_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string"
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "defaults",
+                        "type": "string",
+                        "isRequired": true,
+                        "isResource": true
+                    },
+                    {
+                        "name": "availability_zone",
+                        "type": "string"
+                    },
+                    {
+                        "name": "parameter_group",
+                        "type": "string"
+                    },
+                    {
+                        "name": "overrides",
+                        "type": "json"
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "output_resource_db_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "reset_password",
+                        "type": "string"
+                    },
+                    {
+                        "name": "enhanced_monitoring",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "replica_source",
+                        "type": "string"
+                    },
+                    {
+                        "name": "ca_cert",
+                        "type": "VaultSecret_v1"
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    },
+                    {
+                        "name": "event_notifications",
+                        "type": "AWSRDSEventNotification_v1",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceS3_v1",
+                "interface": "NamespaceTerraformResourceAWS_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string"
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "defaults",
+                        "type": "string",
+                        "isRequired": true,
+                        "isResource": true
+                    },
+                    {
+                        "name": "overrides",
+                        "type": "json"
+                    },
+                    {
+                        "name": "event_notifications",
+                        "type": "AWSS3EventNotification_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "sqs_identifier",
+                        "type": "string"
+                    },
+                    {
+                        "name": "s3_events",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "bucket_policy",
+                        "type": "json"
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "storage_class",
+                        "type": "string"
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceServiceAccountAWSInfrastructureAccess_v1",
+                "fields": [
+                    {
+                        "name": "cluster",
+                        "type": "Cluster_v1"
+                    },
+                    {
+                        "name": "access_level",
+                        "type": "string"
+                    },
+                    {
+                        "name": "assume_role",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceServiceAccount_v1",
+                "interface": "NamespaceTerraformResourceAWS_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "variables",
+                        "type": "json"
+                    },
+                    {
+                        "name": "policies",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "user_policy",
+                        "type": "json"
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "aws_infrastructure_access",
+                        "type": "NamespaceTerraformResourceServiceAccountAWSInfrastructureAccess_v1"
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "AssumeRole_v1",
+                "fields": [
+                    {
+                        "name": "AWS",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "Service",
+                        "type": "string",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceSecretsManagerServiceAccount_v1",
+                "interface": "NamespaceTerraformResourceAWS_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "secrets_prefix",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceRole_v1",
+                "interface": "NamespaceTerraformResourceAWS_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "assume_role",
+                        "type": "AssumeRole_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "assume_condition",
+                        "type": "json"
+                    },
+                    {
+                        "name": "inline_policy",
+                        "type": "json"
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceElastiCache_v1",
+                "interface": "NamespaceTerraformResourceAWS_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "defaults",
+                        "type": "string",
+                        "isRequired": true,
+                        "isResource": true
+                    },
+                    {
+                        "name": "parameter_group",
+                        "type": "string"
+                    },
+                    {
+                        "name": "region",
+                        "type": "string"
+                    },
+                    {
+                        "name": "overrides",
+                        "type": "json"
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "SQSQueuesSpecs_v1",
+                "fields": [
+                    {
+                        "name": "defaults",
+                        "type": "string",
+                        "isRequired": true,
+                        "isResource": true
+                    },
+                    {
+                        "name": "queues",
+                        "type": "KeyValue_v1",
+                        "isRequired": true,
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceSQS_v1",
+                "interface": "NamespaceTerraformResourceAWS_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string"
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "specs",
+                        "type": "SQSQueuesSpecs_v1",
+                        "isRequired": true,
+                        "isList": true
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceSNSSubscription_v1",
+                "fields": [
+                    {
+                        "name": "protocol",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "endpoint",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceSNSTopic_v1",
+                "interface": "NamespaceTerraformResourceAWS_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "defaults",
+                        "type": "string",
+                        "isResource": true,
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string"
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "fifo_topic",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "inline_policy",
+                        "type": "json"
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    },
+                    {
+                        "name": "subscriptions",
+                        "type": "NamespaceTerraformResourceSNSSubscription_v1",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "DynamoDBTableSpecs_v1",
+                "fields": [
+                    {
+                        "name": "defaults",
+                        "type": "string",
+                        "isRequired": true,
+                        "isResource": true
+                    },
+                    {
+                        "name": "tables",
+                        "type": "KeyValue_v1",
+                        "isRequired": true,
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceDynamoDB_v1",
+                "interface": "NamespaceTerraformResourceAWS_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string"
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "specs",
+                        "type": "DynamoDBTableSpecs_v1",
+                        "isRequired": true,
+                        "isList": true
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceECR_v1",
+                "interface": "NamespaceTerraformResourceAWS_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string"
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "mirror",
+                        "type": "ContainerImageMirror_v1",
+                        "isRequired": false
+                    },
+                    {
+                        "name": "public",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceS3CloudFront_v1",
+                "interface": "NamespaceTerraformResourceAWS_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string"
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "defaults",
+                        "type": "string",
+                        "isRequired": true,
+                        "isResource": true
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "storage_class",
+                        "type": "string"
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceS3SQS_v1",
+                "interface": "NamespaceTerraformResourceAWS_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string"
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "kms_encryption",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "defaults",
+                        "type": "string",
+                        "isRequired": true,
+                        "isResource": true
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "storage_class",
+                        "type": "string"
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceCloudWatch_v1",
+                "interface": "NamespaceTerraformResourceAWS_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string"
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "defaults",
+                        "type": "string",
+                        "isRequired": true,
+                        "isResource": true
+                    },
+                    {
+                        "name": "es_identifier",
+                        "type": "string"
+                    },
+                    {
+                        "name": "filter_pattern",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceKMS_v1",
+                "interface": "NamespaceTerraformResourceAWS_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string"
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "defaults",
+                        "type": "string",
+                        "isRequired": true,
+                        "isResource": true
+                    },
+                    {
+                        "name": "overrides",
+                        "type": "json"
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceKinesis_v1",
+                "interface": "NamespaceTerraformResourceAWS_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string"
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "defaults",
+                        "type": "string",
+                        "isRequired": true,
+                        "isResource": true
+                    },
+                    {
+                        "name": "overrides",
+                        "type": "json"
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceALB_v1",
+                "interface": "NamespaceTerraformResourceAWS_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string"
+                    },
+                    {
+                        "name": "vpc",
+                        "type": "AWSVPC_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "certificate_arn",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "idle_timeout",
+                        "type": "int"
+                    },
+                    {
+                        "name": "targets",
+                        "type": "NamespaceTerraformResourceALBTargets_v1",
+                        "isRequired": true,
+                        "isList": true
+                    },
+                    {
+                        "name": "rules",
+                        "type": "NamespaceTerraformResourceALBRules_v1",
+                        "isRequired": true,
+                        "isList": true
+                    },
+                    {
+                        "name": "vpc",
+                        "type": "AWSVPC_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceRoute53Zone_v1",
+                "interface": "NamespaceTerraformResourceAWS_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string"
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceRosaAuthenticator_V1",
+                "interface": "NamespaceTerraformResourceAWS_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "region",
+                        "type": "string"
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "api_proxy_uri",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "sms_role_ext_id",
+                        "type": "string",
+                        "isRequired": false
+                    },
+                    {
+                        "name": "cognito_callback_bucket_name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "pre_signup_lambda_github_release_url",
+                        "type": "string"
+                    },
+                    {
+                        "name": "vpc_arn",
+                        "type": "string",
+                        "isRequired": false
+                    },
+                    {
+                        "name": "vpc_id",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "vpce_id",
+                        "type": "string",
+                        "isRequired": false
+                    },
+                    {
+                        "name": "subnet_ids",
+                        "type": "string",
+                        "isList": true,
+                        "isRequired": true
+                    },
+                    {
+                        "name": "network_interface_ids",
+                        "type": "string",
+                        "isList": true,
+                        "isRequired": false
+                    },
+                    {
+                        "name": "certificate_arn",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "domain_name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "openshift_ingress_load_balancer_arn",
+                        "type": "string",
+                        "isRequired": false
+                    },
+                    {
+                        "name": "defaults",
+                        "type": "string",
+                        "isRequired": true,
+                        "isResource": true
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceRosaAuthenticatorVPCE_V1",
+                "interface": "NamespaceTerraformResourceAWS_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "annotations",
+                        "type": "json"
+                    },
+                    {
+                        "name": "defaults",
+                        "type": "string",
+                        "isRequired": true,
+                        "isResource": true
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "output_format",
+                        "type": "NamespaceTerraformResourceOutputFormat_v1",
+                        "isInterface": true
+                    },
+                    {
+                        "name": "output_resource_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "region",
+                        "type": "string"
+                    },
+                    {
+                        "name": "subnet_ids",
+                        "type": "string",
+                        "isList": true,
+                        "isRequired": true
+                    },
+                    {
+                        "name": "vpc_id",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceALBTargets_v1",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "default",
+                        "type": "boolean",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "ips",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "openshift_service",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceALBRules_v1",
+                "fields": [
+                    {
+                        "name": "condition",
+                        "type": "NamespaceTerraformResourceALBConditon_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "action",
+                        "type": "NamespaceTerraformResourceALBAction_v1",
+                        "isRequired": true,
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceALBConditon_v1",
+                "fields": [
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "methods",
+                        "type": "string",
+                        "isList": true,
+                        "isRequired": false
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceTerraformResourceALBAction_v1",
+                "fields": [
+                    {
+                        "name": "target",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "weight",
+                        "type": "int",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "ResourceValues_v1",
+                "fields": [
+                    {
+                        "name": "cpu",
+                        "type": "string"
+                    },
+                    {
+                        "name": "memory",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "LimitRangeItem_v1",
+                "fields": [
+                    {
+                        "name": "default",
+                        "type": "ResourceValues_v1"
+                    },
+                    {
+                        "name": "defaultRequest",
+                        "type": "ResourceValues_v1"
+                    },
+                    {
+                        "name": "max",
+                        "type": "ResourceValues_v1"
+                    },
+                    {
+                        "name": "maxLimitRequestRatio",
+                        "type": "ResourceValues_v1"
+                    },
+                    {
+                        "name": "min",
+                        "type": "ResourceValues_v1"
+                    },
+                    {
+                        "name": "type",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "LimitRange_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "limits",
+                        "type": "LimitRangeItem_v1",
+                        "isList": true,
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "ResourceQuotaItemResources_v1",
+                "fields": [
+                    {
+                        "name": "limits",
+                        "type": "ResourceValues_v1"
+                    },
+                    {
+                        "name": "requests",
+                        "type": "ResourceValues_v1"
+                    },
+                    {
+                        "name": "pods",
+                        "type": "int"
+                    }
+                ]
+            },
+            {
+                "name": "ResourceQuotaItem_v1",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "resources",
+                        "type": "ResourceQuotaItemResources_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "scopes",
+                        "type": "string",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "ResourceQuota_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "quotas",
+                        "type": "ResourceQuotaItem_v1",
+                        "isList": true,
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceManagedResourceTypeOverrides_v1",
+                "fields": [
+                    {
+                        "name": "resource",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "override",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "NamespaceManagedResourceNames_v1",
+                "fields": [
+                    {
+                        "name": "resource",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "resourceNames",
+                        "type": "string",
+                        "isRequired": true,
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "ServiceAccountTokenSpec_v1",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "namespace",
+                        "type": "Namespace_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "serviceAccountName",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "SharedResources_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true,
+                        "isSearchable": true,
+                        "isUnique": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "openshiftResources",
+                        "type": "NamespaceOpenshiftResource_v1",
+                        "isList": true,
+                        "isInterface": true,
+                        "isRequired": true
+                    },
+                    {
+                        "name": "openshiftServiceAccountTokens",
+                        "type": "ServiceAccountTokenSpec_v1",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "Namespace_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "delete",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "grafanaUrl",
+                        "type": "string"
+                    },
+                    {
+                        "name": "cluster",
+                        "type": "Cluster_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "app",
+                        "type": "App_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "environment",
+                        "type": "Environment_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "limitRanges",
+                        "type": "LimitRange_v1"
+                    },
+                    {
+                        "name": "quota",
+                        "type": "ResourceQuota_v1"
+                    },
+                    {
+                        "name": "networkPoliciesAllow",
+                        "type": "Namespace_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "clusterAdmin",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "managedRoles",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "managedResourceTypes",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "managedResourceTypeOverrides",
+                        "type": "NamespaceManagedResourceTypeOverrides_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "managedResourceNames",
+                        "type": "NamespaceManagedResourceNames_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "sharedResources",
+                        "type": "SharedResources_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "openshiftResources",
+                        "type": "NamespaceOpenshiftResource_v1",
+                        "isList": true,
+                        "isInterface": true
+                    },
+                    {
+                        "name": "managedExternalResources",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "externalResources",
+                        "type": "NamespaceExternalResource_v1",
+                        "isList": true,
+                        "isInterface": true
+                    },
+                    {
+                        "name": "openshiftServiceAccountTokens",
+                        "type": "ServiceAccountTokenSpec_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "kafkaCluster",
+                        "type": "KafkaCluster_v1"
+                    }
+                ]
+            },
+            {
+                "name": "Owner_v1",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "email",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "Dependency_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "statefulness",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "opsModel",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "statusPage",
+                        "type": "string"
+                    },
+                    {
+                        "name": "SLA",
+                        "type": "float",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "dependencyFailureImpact",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "AppGcrReposItems_v1",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "public",
+                        "type": "boolean",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "mirror",
+                        "type": "ContainerImageMirror_v1",
+                        "isRequired": false
+                    }
+                ]
+            },
+            {
+                "name": "OcpReleaseMirror_v1",
+                "fields": [
+                    {
+                        "name": "hiveCluster",
+                        "type": "Cluster_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "ecrResourcesNamespace",
+                        "type": "Namespace_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "ocpReleaseEcrIdentifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "ocpArtDevEcrIdentifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "quayTargetOrgs",
+                        "type": "QuayOrg_v1",
+                        "isRequired": true,
+                        "isList": true
+                    },
+                    {
+                        "name": "mirrorChannels",
+                        "type": "string",
+                        "isRequired": true,
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "ContainerImageMirror_v1",
+                "fields": [
+                    {
+                        "name": "url",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "pullCredentials",
+                        "type": "VaultSecret_v1"
+                    },
+                    {
+                        "name": "tags",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "tagsExclude",
+                        "type": "string",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "AppGcrRepos_v1",
+                "fields": [
+                    {
+                        "name": "project",
+                        "type": "GcpProject_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "items",
+                        "type": "AppGcrReposItems_v1",
+                        "isRequired": true,
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "AppQuayReposItems_v1",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "public",
+                        "type": "boolean",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "mirror",
+                        "type": "ContainerImageMirror_v1",
+                        "isRequired": false
+                    }
+                ]
+            },
+            {
+                "name": "AppQuayReposTeams_v1",
+                "fields": [
+                    {
+                        "name": "permissions",
+                        "type": "PermissionQuayOrgTeam_v1",
+                        "isList": true,
+                        "isRequired": true
+                    },
+                    {
+                        "name": "role",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "AppQuayReposNotificationVerificationMethod_v1",
+                "fields": [
+                    {
+                        "name": "jiraBoard",
+                        "type": "JiraBoard_v1"
+                    }
+                ]
+            },
+            {
+                "name": "AppQuayReposNotifications_v1",
+                "fields": [
+                    {
+                        "name": "event",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "severity",
+                        "type": "string"
+                    },
+                    {
+                        "name": "method",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "escalationPolicy",
+                        "type": "AppEscalationPolicy_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "verificationMethod",
+                        "type": "AppQuayReposNotificationVerificationMethod_v1"
+                    }
+                ]
+            },
+            {
+                "name": "AppQuayRepos_v1",
+                "fields": [
+                    {
+                        "name": "org",
+                        "type": "QuayOrg_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "teams",
+                        "type": "AppQuayReposTeams_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "notifications",
+                        "type": "AppQuayReposNotifications_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "items",
+                        "type": "AppQuayReposItems_v1",
+                        "isRequired": true,
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "AppEscalationPolicy_v1",
+                "fields": [
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "channels",
+                        "type": "AppEscalationPolicyChannels_v1",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "AppEscalationPolicyChannels_v1",
+                "fields": [
+                    {
+                        "name": "slackUserGroup",
+                        "type": "PermissionSlackUsergroup_v1",
+                        "isList": true,
+                        "isRequired": true
+                    },
+                    {
+                        "name": "email",
+                        "type": "string",
+                        "isList": true,
+                        "isRequired": true
+                    },
+                    {
+                        "name": "pagerduty",
+                        "type": "PagerDutyTarget_v1"
+                    },
+                    {
+                        "name": "jiraBoard",
+                        "type": "JiraBoard_v1",
+                        "isList": true,
+                        "isRequired": true
+                    },
+                    {
+                        "name": "nextEscalationPolicy",
+                        "type": "AppEscalationPolicy_v1"
+                    }
+                ]
+            },
+            {
+                "name": "AppEndPoints_v1",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "url",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "monitoring",
+                        "type": "AppEndPointMonitoring_v1",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "AppEndPointMonitoring_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "EndpointMonitoringProvider_v1",
+                        "isInterface": true
+                    }
+                ]
+            },
+            {
+                "name": "CodeComponentGitlabOwners_v1",
+                "fields": [
+                    {
+                        "name": "enabled",
+                        "type": "boolean",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "CodeComponentGitlabHousekeeping_v1",
+                "fields": [
+                    {
+                        "name": "enabled",
+                        "type": "boolean",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "rebase",
+                        "type": "boolean",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "days_interval",
+                        "type": "int"
+                    },
+                    {
+                        "name": "limit",
+                        "type": "int"
+                    },
+                    {
+                        "name": "enable_closing",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "pipeline_timeout",
+                        "type": "int"
+                    }
+                ]
+            },
+            {
+                "name": "AppCodeComponents_v1",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "resource",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "url",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "gitlabRepoOwners",
+                        "type": "CodeComponentGitlabOwners_v1"
+                    },
+                    {
+                        "name": "gitlabHousekeeping",
+                        "type": "CodeComponentGitlabHousekeeping_v1"
+                    },
+                    {
+                        "name": "jira",
+                        "type": "JiraServer_v1"
+                    },
+                    {
+                        "name": "mirror",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "Product_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "productOwners",
+                        "type": "Owner_v1",
+                        "isList": true,
+                        "isRequired": true
+                    },
+                    {
+                        "name": "environments",
+                        "type": "Environment_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/app-sre/environment-1.yml",
+                            "subAttr": "product"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "Environment_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "product",
+                        "type": "Product_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "parameters",
+                        "type": "json"
+                    },
+                    {
+                        "name": "secretParameters",
+                        "type": "SaasSecretParameters_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "dependsOn",
+                        "type": "Environment_v1"
+                    },
+                    {
+                        "name": "namespaces",
+                        "type": "Namespace_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/openshift/namespace-1.yml",
+                            "subAttr": "environment"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "App_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true,
+                        "isSearchable": true,
+                        "isUnique": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "onboardingStatus",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "grafanaUrls",
+                        "isList": true,
+                        "type": "GrafanaDashboardUrls_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "sopsUrl",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "architectureDocument",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "parentApp",
+                        "type": "App_v1"
+                    },
+                    {
+                        "name": "serviceDocs",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "serviceOwners",
+                        "type": "Owner_v1",
+                        "isList": true,
+                        "isRequired": true
+                    },
+                    {
+                        "name": "serviceNotifications",
+                        "type": "Owner_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "dependencies",
+                        "type": "Dependency_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "gcrRepos",
+                        "type": "AppGcrRepos_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "quayRepos",
+                        "type": "AppQuayRepos_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "escalationPolicy",
+                        "type": "AppEscalationPolicy_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "endPoints",
+                        "type": "AppEndPoints_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "codeComponents",
+                        "type": "AppCodeComponents_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "sentryProjects",
+                        "type": "AppSentryProjects_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "statusPageComponents",
+                        "type": "StatusPageComponent_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "namespaces",
+                        "type": "Namespace_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/openshift/namespace-1.yml",
+                            "subAttr": "app"
+                        }
+                    },
+                    {
+                        "name": "childrenApps",
+                        "type": "App_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/app-sre/app-1.yml",
+                            "subAttr": "parentApp"
+                        }
+                    },
+                    {
+                        "name": "jenkinsConfigs",
+                        "type": "JenkinsConfig_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/dependencies/jenkins-config-1.yml",
+                            "subAttr": "app"
+                        }
+                    },
+                    {
+                        "name": "saasFiles",
+                        "type": "SaasFile_v2",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/app-sre/saas-file-2.yml",
+                            "subAttr": "app"
+                        }
+                    },
+                    {
+                        "name": "sreCheckpoints",
+                        "type": "SRECheckpoint_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/app-sre/sre-checkpoint-1.yml",
+                            "subAttr": "app"
+                        }
+                    },
+                    {
+                        "name": "sloDocuments",
+                        "type": "SLODocument_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/app-sre/slo-document-1.yml",
+                            "subAttr": "app"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "SaasFile_v2",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true,
+                        "isSearchable": true,
+                        "isUnique": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "app",
+                        "type": "App_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "pipelinesProvider",
+                        "type": "PipelinesProvider_v1",
+                        "isRequired": true,
+                        "isInterface": true
+                    },
+                    {
+                        "name": "slack",
+                        "type": "SlackOutput_v1"
+                    },
+                    {
+                        "name": "managedResourceTypes",
+                        "type": "string",
+                        "isRequired": true,
+                        "isList": true
+                    },
+                    {
+                        "name": "authentication",
+                        "type": "SaasFileAuthentication_v1"
+                    },
+                    {
+                        "name": "parameters",
+                        "type": "json"
+                    },
+                    {
+                        "name": "secretParameters",
+                        "type": "SaasSecretParameters_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "resourceTemplates",
+                        "type": "SaasResourceTemplate_v2",
+                        "isRequired": true,
+                        "isList": true
+                    },
+                    {
+                        "name": "imagePatterns",
+                        "type": "string",
+                        "isRequired": true,
+                        "isList": true
+                    },
+                    {
+                        "name": "takeover",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "compare",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "publishJobLogs",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "clusterAdmin",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "use_channel_in_image_tag",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "configurableResources",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "deployResources",
+                        "type": "DeployResources_v1"
+                    },
+                    {
+                        "name": "roles",
+                        "type": "Role_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/access/role-1.yml",
+                            "subAttr": "owned_saas_files"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "DeployResources_v1",
+                "fields": [
+                    {
+                        "name": "requests",
+                        "type": "ResourceRequirements_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "limits",
+                        "type": "ResourceRequirements_v1",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "ResourceRequirements_v1",
+                "fields": [
+                    {
+                        "name": "cpu",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "memory",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "SlackOutputNotifications_v1",
+                "fields": [
+                    {
+                        "name": "start",
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "SlackOutput_v1",
+                "fields": [
+                    {
+                        "name": "workspace",
+                        "type": "SlackWorkspace_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "channel",
+                        "type": "string"
+                    },
+                    {
+                        "name": "icon_emoji",
+                        "type": "string"
+                    },
+                    {
+                        "name": "username",
+                        "type": "string"
+                    },
+                    {
+                        "name": "output",
+                        "type": "string"
+                    },
+                    {
+                        "name": "notifications",
+                        "type": "SlackOutputNotifications_v1"
+                    }
+                ]
+            },
+            {
+                "name": "SaasFileAuthentication_v1",
+                "fields": [
+                    {
+                        "name": "code",
+                        "type": "VaultSecret_v1"
+                    },
+                    {
+                        "name": "image",
+                        "type": "VaultSecret_v1"
+                    }
+                ]
+            },
+            {
+                "name": "SaasResourceTemplate_v2",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "url",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "provider",
+                        "type": "string"
+                    },
+                    {
+                        "name": "hash_length",
+                        "type": "int"
+                    },
+                    {
+                        "name": "parameters",
+                        "type": "json"
+                    },
+                    {
+                        "name": "secretParameters",
+                        "type": "SaasSecretParameters_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "targets",
+                        "type": "SaasResourceTemplateTarget_v2",
+                        "isRequired": true,
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "SaasResourceTemplateTarget_v2",
+                "fields": [
+                    {
+                        "name": "path",
+                        "type": "string"
+                    },
+                    {
+                        "name": "namespace",
+                        "type": "Namespace_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "ref",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "promotion",
+                        "type": "SaasResourceTemplateTargetPromotion_v1"
+                    },
+                    {
+                        "name": "parameters",
+                        "type": "json"
+                    },
+                    {
+                        "name": "secretParameters",
+                        "type": "SaasSecretParameters_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "upstream",
+                        "type": "SaasResourceTemplateTargetUpstream_v1"
+                    },
+                    {
+                        "name": "disable",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "delete",
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "SaasResourceTemplateTargetUpstream_v1",
+                "fields": [
+                    {
+                        "name": "instance",
+                        "type": "JenkinsInstance_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "SaasResourceTemplateTargetPromotion_v1",
+                "fields": [
+                    {
+                        "name": "auto",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "publish",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "subscribe",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "promotion_data",
+                        "type": "PromotionData_v1",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "SaasSecretParameters_v1",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "secret",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "PromotionData_v1",
+                "fields": [
+                    {
+                        "name": "channel",
+                        "type": "string"
+                    },
+                    {
+                        "name": "data",
+                        "type": "PromotionChannelData_v1",
+                        "isList": true,
+                        "isInterface": true
+                    }
+                ]
+            },
+            {
+                "name": "PromotionChannelData_v1",
+                "isInterface": true,
+                "interfaceResolve": {
+                    "strategy": "fieldMap",
+                    "field": "type",
+                    "fieldMap": {
+                        "parent_saas_config": "ParentSaasPromotion_v1"
+                    }
+                },
+                "fields": [
+                    {
+                        "name": "type",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "ParentSaasPromotion_v1",
+                "interface": "PromotionChannelData_v1",
+                "fields": [
+                    {
+                        "name": "type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "parent_saas",
+                        "type": "string"
+                    },
+                    {
+                        "name": "target_config_hash",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "PipelinesProvider_v1",
+                "isInterface": true,
+                "interfaceResolve": {
+                    "strategy": "fieldMap",
+                    "field": "provider",
+                    "fieldMap": {
+                        "tekton": "PipelinesProviderTekton_v1"
+                    }
+                },
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "PipelinesProviderTekton_v1",
+                "interface": "PipelinesProvider_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "defaults",
+                        "type": "PipelinesProviderTektonProviderDefaults_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "namespace",
+                        "type": "Namespace_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "retention",
+                        "type": "PipelinesProviderRetention_v1"
+                    },
+                    {
+                        "name": "taskTemplates",
+                        "type": "PipelinesProviderTektonObjectTemplate_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "pipelineTemplates",
+                        "type": "PipelinesProviderPipelineTemplates_v1"
+                    },
+                    {
+                        "name": "deployResources",
+                        "type": "DeployResources_v1"
+                    }
+                ]
+            },
+            {
+                "name": "PipelinesProviderRetention_v1",
+                "fields": [
+                    {
+                        "name": "days",
+                        "type": "int"
+                    },
+                    {
+                        "name": "minimum",
+                        "type": "int"
+                    }
+                ]
+            },
+            {
+                "name": "PipelinesProviderTektonObjectTemplate_v1",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "variables",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "PipelinesProviderPipelineTemplates_v1",
+                "fields": [
+                    {
+                        "name": "openshiftSaasDeploy",
+                        "type": "PipelinesProviderTektonObjectTemplate_v1",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "PipelinesProviderTektonProviderDefaults_v1",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "retention",
+                        "type": "PipelinesProviderRetention_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "taskTemplates",
+                        "type": "PipelinesProviderTektonObjectTemplate_v1",
+                        "isRequired": true,
+                        "isList": true
+                    },
+                    {
+                        "name": "pipelineTemplates",
+                        "type": "PipelinesProviderPipelineTemplates_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "deployResources",
+                        "type": "DeployResources_v1"
+                    }
+                ]
+            },
+            {
+                "name": "VaultInstance_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "address",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "auth",
+                        "type": "VaultInstanceAuth_v1",
+                        "isInterface": true,
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "VaultInstanceAuth_v1",
+                "isInterface": true,
+                "interfaceResolve": {
+                    "strategy": "fieldMap",
+                    "field": "provider",
+                    "fieldMap": {
+                        "approle": "VaultInstanceAuthApprole_v1",
+                        "token": "VaultInstanceAuthToken_v1"
+                    }
+                },
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "secretEngine",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "VaultInstanceAuthApprole_v1",
+                "interface": "VaultInstanceAuth_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "secretEngine",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "roleID",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "secretID",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "VaultInstanceAuthToken_v1",
+                "interface": "VaultInstanceAuth_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "secretEngine",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "OidcPermission_v1",
+                "isInterface": true,
+                "interfaceResolve": {
+                    "strategy": "fieldMap",
+                    "field": "service",
+                    "fieldMap": {
+                        "vault": "OidcPermissionVault_v1"
+                    }
+                },
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "service",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "OidcPermissionVault_v1",
+                "interface": "OidcPermission_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "service",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "instance",
+                        "type": "VaultInstance_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "vault_policies",
+                        "type": "VaultPolicy_v1",
+                        "isList": true,
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "Permission_v1",
+                "isInterface": true,
+                "interfaceResolve": {
+                    "strategy": "fieldMap",
+                    "field": "service",
+                    "fieldMap": {
+                        "github-org": "PermissionGithubOrg_v1",
+                        "github-org-team": "PermissionGithubOrgTeam_v1",
+                        "quay-membership": "PermissionQuayOrgTeam_v1",
+                        "jenkins-role": "PermissionJenkinsRole_v1",
+                        "slack-usergroup": "PermissionSlackUsergroup_v1",
+                        "gitlab-group-membership": "PermissionGitlabGroupMembership_v1"
+                    }
+                },
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "service",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "PermissionGithubOrg_v1",
+                "interface": "Permission_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "service",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "org",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "role",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "PermissionGithubOrgTeam_v1",
+                "interface": "Permission_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "service",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "org",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "team",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "role",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "PermissionJenkinsRole_v1",
+                "interface": "Permission_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "service",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "instance",
+                        "type": "JenkinsInstance_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "role",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "PermissionGitlabGroupMembership_v1",
+                "interface": "Permission_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "service",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "group",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "access",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "pagerduty",
+                        "type": "PagerDutyTarget_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "roles",
+                        "type": "Role_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/access/role-1.yml",
+                            "subAttr": "permissions"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "PermissionSlackUsergroup_v1",
+                "interface": "Permission_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "service",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "handle",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "workspace",
+                        "type": "SlackWorkspace_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "pagerduty",
+                        "type": "PagerDutyTarget_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "channels",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "ownersFromRepos",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "schedule",
+                        "type": "Schedule_v1"
+                    },
+                    {
+                        "name": "skip",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "roles",
+                        "type": "Role_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/access/role-1.yml",
+                            "subAttr": "permissions"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "Schedule_v1",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string"
+                    },
+                    {
+                        "name": "schedule",
+                        "type": "ScheduleEntry_v1",
+                        "isRequired": true,
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "ScheduleEntry_v1",
+                "fields": [
+                    {
+                        "name": "start",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "end",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "users",
+                        "type": "User_v1",
+                        "isRequired": true,
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "VaultPolicyMapping_v1",
+                "fields": [
+                    {
+                        "name": "github_team",
+                        "type": "PermissionGithubOrgTeam_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "policies",
+                        "type": "VaultPolicy_v1",
+                        "isList": true,
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "VaultAuth_v1",
+                "fields": [
+                    {
+                        "name": "_path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "instance",
+                        "type": "VaultInstance_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "settings",
+                        "type": "VaultAuthSettings_v1"
+                    },
+                    {
+                        "name": "policy_mappings",
+                        "type": "VaultPolicyMapping_v1",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "PermissionQuayOrgTeam_v1",
+                "interface": "Permission_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "service",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "quayOrg",
+                        "type": "QuayOrg_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "team",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "ExternalUser_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "github_username",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "sponsors",
+                        "type": "User_v1",
+                        "isRequired": true,
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "User_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "org_username",
+                        "type": "string",
+                        "isSearchable": true,
+                        "isRequired": true,
+                        "isUnique": true
+                    },
+                    {
+                        "name": "github_username",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "quay_username",
+                        "type": "string"
+                    },
+                    {
+                        "name": "slack_username",
+                        "type": "string"
+                    },
+                    {
+                        "name": "pagerduty_username",
+                        "type": "string"
+                    },
+                    {
+                        "name": "aws_username",
+                        "type": "string"
+                    },
+                    {
+                        "name": "public_gpg_key",
+                        "type": "string"
+                    },
+                    {
+                        "name": "tag_on_merge_requests",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "tag_on_cluster_updates",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "roles",
+                        "type": "Role_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "requests",
+                        "type": "CredentialsRequest_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/app-interface/credentials-request-1.yml",
+                            "subAttr": "user"
+                        }
+                    },
+                    {
+                        "name": "queries",
+                        "type": "AppInterfaceSqlQuery_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/app-interface/app-interface-sql-query-1.yml",
+                            "subAttr": "user"
+                        }
+                    },
+                    {
+                        "name": "gabi_instances",
+                        "type": "GabiInstance_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/app-sre/gabi-instance-1.yml",
+                            "subAttr": "users"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "Bot_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string"
+                    },
+                    {
+                        "name": "org_username",
+                        "type": "string"
+                    },
+                    {
+                        "name": "github_username",
+                        "type": "string"
+                    },
+                    {
+                        "name": "gitlab_username",
+                        "type": "string"
+                    },
+                    {
+                        "name": "openshift_serviceaccount",
+                        "type": "string"
+                    },
+                    {
+                        "name": "quay_username",
+                        "type": "string"
+                    },
+                    {
+                        "name": "owner",
+                        "type": "User_v1"
+                    },
+                    {
+                        "name": "roles",
+                        "type": "Role_v1",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "Access_v1",
+                "fields": [
+                    {
+                        "name": "namespace",
+                        "type": "Namespace_v1"
+                    },
+                    {
+                        "name": "role",
+                        "type": "string"
+                    },
+                    {
+                        "name": "cluster",
+                        "type": "Cluster_v1"
+                    },
+                    {
+                        "name": "group",
+                        "type": "string"
+                    },
+                    {
+                        "name": "clusterRole",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "Role_v1",
+                "datafile": "/access/role-1.yml",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true,
+                        "isUnique": true,
+                        "isSearchable": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string"
+                    },
+                    {
+                        "name": "expirationDate",
+                        "type": "string"
+                    },
+                    {
+                        "name": "permissions",
+                        "type": "Permission_v1",
+                        "isList": true,
+                        "isInterface": true
+                    },
+                    {
+                        "name": "oidc_permissions",
+                        "type": "OidcPermission_v1",
+                        "isList": true,
+                        "isInterface": true
+                    },
+                    {
+                        "name": "tag_on_cluster_updates",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "access",
+                        "type": "Access_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "aws_groups",
+                        "type": "AWSGroup_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "user_policies",
+                        "type": "AWSUserPolicy_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "sentry_teams",
+                        "type": "SentryTeam_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "sentry_roles",
+                        "type": "SentryRole_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "sendgrid_accounts",
+                        "type": "SendGridAccount_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "owned_saas_files",
+                        "type": "SaasFile_v2",
+                        "isList": true
+                    },
+                    {
+                        "name": "users",
+                        "type": "User_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/access/user-1.yml",
+                            "subAttr": "roles"
+                        }
+                    },
+                    {
+                        "name": "bots",
+                        "type": "Bot_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/access/bot-1.yml",
+                            "subAttr": "roles"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "IntegrationPrCheck_v1",
+                "fields": [
+                    {
+                        "name": "cmd",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "state",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "sqs",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "disabled",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "always_run",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "no_validate_schemas",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "run_for_valid_saas_file_changes",
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "IntegrationSpecExtraEnv_v1",
+                "fields": [
+                    {
+                        "name": "secretName",
+                        "type": "string"
+                    },
+                    {
+                        "name": "secretKey",
+                        "type": "string"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "value",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "IntegrationSpecLogs_v1",
+                "fields": [
+                    {
+                        "name": "slack",
+                        "type": "boolean"
+                    }
+                ]
+            },
+            {
+                "name": "IntegrationSpec_v1",
+                "fields": [
+                    {
+                        "name": "cache",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "command",
+                        "type": "string"
+                    },
+                    {
+                        "name": "disableUnleash",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "environmentAware",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "extraArgs",
+                        "type": "string"
+                    },
+                    {
+                        "name": "extraEnv",
+                        "type": "IntegrationSpecExtraEnv_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "internalCertificates",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "logs",
+                        "type": "IntegrationSpecLogs_v1"
+                    },
+                    {
+                        "name": "resources",
+                        "type": "DeployResources_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "shards",
+                        "type": "int"
+                    },
+                    {
+                        "name": "shardingStrategy",
+                        "type": "string"
+                    },
+                    {
+                        "name": "sleepDurationSecs",
+                        "type": "int"
+                    },
+                    {
+                        "name": "state",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "storage",
+                        "type": "string"
+                    },
+                    {
+                        "name": "trigger",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "cron",
+                        "type": "string"
+                    },
+                    {
+                        "name": "dashdotdb",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "concurrencyPolicy",
+                        "type": "string"
+                    },
+                    {
+                        "name": "restartPolicy",
+                        "type": "string"
+                    },
+                    {
+                        "name": "successfulJobHistoryLimit",
+                        "type": "int"
+                    },
+                    {
+                        "name": "failedJobHistoryLimit",
+                        "type": "int"
+                    }
+                ]
+            },
+            {
+                "name": "IntegrationManaged_v1",
+                "fields": [
+                    {
+                        "name": "namespace",
+                        "type": "Namespace_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "spec",
+                        "type": "IntegrationSpec_v1",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "Integration_v1",
+                "datafile": "/app-sre/integration-1.yml",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "upstream",
+                        "type": "string"
+                    },
+                    {
+                        "name": "schemas",
+                        "type": "string",
+                        "isRequired": true,
+                        "isList": true
+                    },
+                    {
+                        "name": "pr_check",
+                        "type": "IntegrationPrCheck_v1"
+                    },
+                    {
+                        "name": "managed",
+                        "type": "IntegrationManaged_v1",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "Report_v1",
+                "datafile": "/app-sre/report-1.yml",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "app",
+                        "type": "App_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "date",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "contentFormatVersion",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "content",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "SRECheckpoint_v1",
+                "datafile": "/app-sre/sre-checkpoint-1.yml",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "app",
+                        "type": "App_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "date",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "issue",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "AppInterfaceSqlQuery_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true,
+                        "isUnique": true
+                    },
+                    {
+                        "name": "namespace",
+                        "type": "Namespace_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "requestor",
+                        "type": "User_v1"
+                    },
+                    {
+                        "name": "overrides",
+                        "type": "SqlEmailOverrides_v1"
+                    },
+                    {
+                        "name": "output",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "schedule",
+                        "type": "string"
+                    },
+                    {
+                        "name": "delete",
+                        "type": "boolean"
+                    },
+                    {
+                        "name": "query",
+                        "type": "string"
+                    },
+                    {
+                        "name": "queries",
+                        "type": "string",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "QontractQuery_v1",
+                "fields": [
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true,
+                        "isResource": true
+                    }
+                ]
+            },
+            {
+                "name": "QueryValidation_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true,
+                        "isUnique": true,
+                        "isSearchable": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "escalationPolicy",
+                        "type": "AppEscalationPolicy_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "queries",
+                        "type": "QontractQuery_v1",
+                        "isList": true,
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "UnleashNotifications_v1",
+                "fields": [
+                    {
+                        "name": "slack",
+                        "type": "SlackOutput_v1",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "UnleashFeatureToggle_v1",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "enabled",
+                        "type": "boolean",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "reason",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "UnleashInstance_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "url",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "token",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "notifications",
+                        "type": "UnleashNotifications_v1"
+                    },
+                    {
+                        "name": "featureToggles",
+                        "type": "UnleashFeatureToggle_v1",
+                        "isRequired": true,
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "GabiNamespace_v1",
+                "fields": [
+                    {
+                        "name": "account",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "identifier",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "namespace",
+                        "type": "Namespace_v1",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "GabiInstance_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "signoffManagers",
+                        "type": "User_v1",
+                        "isRequired": true,
+                        "isList": true
+                    },
+                    {
+                        "name": "users",
+                        "type": "User_v1",
+                        "isRequired": true,
+                        "isList": true
+                    },
+                    {
+                        "name": "instances",
+                        "type": "GabiNamespace_v1",
+                        "isRequired": true,
+                        "isList": true
+                    },
+                    {
+                        "name": "expirationDate",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "TemplateTest_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "resourcePath",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "expectedResult",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "Query",
+                "fields": [
+                    {
+                        "name": "app_interface_settings_v1",
+                        "type": "AppInterfaceSettings_v1",
+                        "isList": true,
+                        "datafileSchema": "/app-interface/app-interface-settings-1.yml"
+                    },
+                    {
+                        "name": "app_interface_emails_v1",
+                        "type": "AppInterfaceEmail_v1",
+                        "isList": true,
+                        "datafileSchema": "/app-interface/app-interface-email-1.yml"
+                    },
+                    {
+                        "name": "app_interface_slack_notifications_v1",
+                        "type": "AppInterfaceSlackNotification_v1",
+                        "isList": true,
+                        "datafileSchema": "/app-interface/app-interface-slack-notification-1.yml"
+                    },
+                    {
+                        "name": "credentials_requests_v1",
+                        "type": "CredentialsRequest_v1",
+                        "isList": true,
+                        "datafileSchema": "/app-interface/credentials-request-1.yml"
+                    },
+                    {
+                        "name": "users_v1",
+                        "type": "User_v1",
+                        "isList": true,
+                        "datafileSchema": "/access/user-1.yml"
+                    },
+                    {
+                        "name": "external_users_v1",
+                        "type": "ExternalUser_v1",
+                        "isList": true,
+                        "datafileSchema": "/access/external-user-1.yml"
+                    },
+                    {
+                        "name": "bots_v1",
+                        "type": "Bot_v1",
+                        "isList": true,
+                        "datafileSchema": "/access/bot-1.yml"
+                    },
+                    {
+                        "name": "roles_v1",
+                        "type": "Role_v1",
+                        "isList": true,
+                        "datafileSchema": "/access/role-1.yml"
+                    },
+                    {
+                        "name": "permissions_v1",
+                        "type": "Permission_v1",
+                        "isList": true,
+                        "isInterface": true,
+                        "datafileSchema": "/access/permission-1.yml"
+                    },
+                    {
+                        "name": "awsgroups_v1",
+                        "type": "AWSGroup_v1",
+                        "isList": true,
+                        "datafileSchema": "/aws/group-1.yml"
+                    },
+                    {
+                        "name": "awsaccounts_v1",
+                        "type": "AWSAccount_v1",
+                        "isList": true,
+                        "datafileSchema": "/aws/account-1.yml"
+                    },
+                    {
+                        "name": "clusters_v1",
+                        "type": "Cluster_v1",
+                        "isList": true,
+                        "datafileSchema": "/openshift/cluster-1.yml"
+                    },
+                    {
+                        "name": "jumphosts_v1",
+                        "type": "ClusterJumpHost_v1",
+                        "isList": true,
+                        "datafileSchema": "/openshift/jump-host-1.yml"
+                    },
+                    {
+                        "name": "kafka_clusters_v1",
+                        "type": "KafkaCluster_v1",
+                        "isList": true,
+                        "datafileSchema": "/kafka/cluster-1.yml"
+                    },
+                    {
+                        "name": "namespaces_v1",
+                        "type": "Namespace_v1",
+                        "isList": true,
+                        "datafileSchema": "/openshift/namespace-1.yml"
+                    },
+                    {
+                        "name": "gcp_projects_v1",
+                        "type": "GcpProject_v1",
+                        "isList": true,
+                        "datafileSchema": "/gcp/project-1.yml"
+                    },
+                    {
+                        "name": "quay_orgs_v1",
+                        "type": "QuayOrg_v1",
+                        "isList": true,
+                        "datafileSchema": "/dependencies/quay-org-1.yml"
+                    },
+                    {
+                        "name": "quay_instances_v1",
+                        "type": "QuayInstance_v1",
+                        "isList": true,
+                        "datafileSchema": "/dependencies/quay-instance-1.yml"
+                    },
+                    {
+                        "name": "jenkins_instances_v1",
+                        "type": "JenkinsInstance_v1",
+                        "isList": true,
+                        "datafileSchema": "/dependencies/jenkins-instance-1.yml"
+                    },
+                    {
+                        "name": "jenkins_configs_v1",
+                        "type": "JenkinsConfig_v1",
+                        "isList": true,
+                        "datafileSchema": "/dependencies/jenkins-config-1.yml"
+                    },
+                    {
+                        "name": "jira_servers_v1",
+                        "type": "JiraServer_v1",
+                        "isList": true,
+                        "datafileSchema": "/dependencies/jira-server-1.yml"
+                    },
+                    {
+                        "name": "jira_boards_v1",
+                        "type": "JiraBoard_v1",
+                        "isList": true,
+                        "datafileSchema": "/dependencies/jira-board-1.yml"
+                    },
+                    {
+                        "name": "sendgrid_accounts_v1",
+                        "type": "SendGridAccount_v1",
+                        "isList": true,
+                        "datafileSchema": "/dependencies/sendgrid-account-1.yml"
+                    },
+                    {
+                        "name": "products_v1",
+                        "type": "Product_v1",
+                        "isList": true,
+                        "datafileSchema": "/app-sre/product-1.yml"
+                    },
+                    {
+                        "name": "environments_v1",
+                        "type": "Environment_v1",
+                        "isList": true,
+                        "datafileSchema": "/app-sre/environment-1.yml"
+                    },
+                    {
+                        "name": "apps_v1",
+                        "type": "App_v1",
+                        "isList": true,
+                        "datafileSchema": "/app-sre/app-1.yml"
+                    },
+                    {
+                        "name": "escalation_policies_1",
+                        "type": "AppEscalationPolicy_v1",
+                        "isList": true,
+                        "datafileSchema": "/app-sre/escalation-policy-1.yml"
+                    },
+                    {
+                        "name": "resources_v1",
+                        "type": "Resource_v1",
+                        "isResource": true,
+                        "isRequired": true,
+                        "isList": true
+                    },
+                    {
+                        "name": "vault_instances_v1",
+                        "type": "VaultInstance_v1",
+                        "isList": true,
+                        "datafileSchema": "/vault-config/instance-1.yml"
+                    },
+                    {
+                        "name": "vault_audit_backends_v1",
+                        "type": "VaultAudit_v1",
+                        "isList": true,
+                        "datafileSchema": "/vault-config/audit-1.yml"
+                    },
+                    {
+                        "name": "vault_auth_backends_v1",
+                        "type": "VaultAuth_v1",
+                        "isList": true,
+                        "datafileSchema": "/vault-config/auth-1.yml"
+                    },
+                    {
+                        "name": "vault_secret_engines_v1",
+                        "type": "VaultSecretEngine_v1",
+                        "isList": true,
+                        "datafileSchema": "/vault-config/secret-engine-1.yml"
+                    },
+                    {
+                        "name": "vault_roles_v1",
+                        "type": "VaultRole_v1",
+                        "isList": true,
+                        "datafileSchema": "/vault-config/role-1.yml"
+                    },
+                    {
+                        "name": "vault_policies_v1",
+                        "type": "VaultPolicy_v1",
+                        "isList": true,
+                        "datafileSchema": "/vault-config/policy-1.yml"
+                    },
+                    {
+                        "name": "dependencies_v1",
+                        "type": "Dependency_v1",
+                        "isList": true,
+                        "datafileSchema": "/dependencies/dependency-1.yml"
+                    },
+                    {
+                        "name": "githuborg_v1",
+                        "type": "GithubOrg_v1",
+                        "isList": true,
+                        "datafileSchema": "/dependencies/github-org-1.yml"
+                    },
+                    {
+                        "name": "gitlabinstance_v1",
+                        "type": "GitlabInstance_v1",
+                        "isList": true,
+                        "datafileSchema": "/dependencies/gitlab-instance-1.yml"
+                    },
+                    {
+                        "name": "integrations_v1",
+                        "type": "Integration_v1",
+                        "isList": true,
+                        "datafileSchema": "/app-sre/integration-1.yml"
+                    },
+                    {
+                        "name": "reports_v1",
+                        "type": "Report_v1",
+                        "isList": true,
+                        "datafileSchema": "/app-sre/report-1.yml"
+                    },
+                    {
+                        "name": "sre_checkpoints_v1",
+                        "type": "SRECheckpoint_v1",
+                        "isList": true,
+                        "datafileSchema": "/app-sre/sre-checkpoint-1.yml"
+                    },
+                    {
+                        "name": "sentry_teams_v1",
+                        "type": "SentryTeam_v1",
+                        "isList": true,
+                        "datafileSchema": "/dependencies/sentry-team-1.yml"
+                    },
+                    {
+                        "name": "sentry_instances_v1",
+                        "type": "SentryInstance_v1",
+                        "isList": true,
+                        "datafileSchema": "/dependencies/sentry-instance-1.yml"
+                    },
+                    {
+                        "name": "app_interface_sql_queries_v1",
+                        "type": "AppInterfaceSqlQuery_v1",
+                        "isList": true,
+                        "datafileSchema": "/app-interface/app-interface-sql-query-1.yml"
+                    },
+                    {
+                        "name": "query_validations_v1",
+                        "type": "QueryValidation_v1",
+                        "isList": true,
+                        "datafileSchema": "/app-interface/query-validation-1.yml"
+                    },
+                    {
+                        "name": "saas_files_v2",
+                        "type": "SaasFile_v2",
+                        "isList": true,
+                        "datafileSchema": "/app-sre/saas-file-2.yml"
+                    },
+                    {
+                        "name": "pipelines_providers_v1",
+                        "type": "PipelinesProvider_v1",
+                        "isList": true,
+                        "isInterface": true,
+                        "datafileSchema": "/app-sre/pipelines-provider-1.yml"
+                    },
+                    {
+                        "name": "unleash_instances_v1",
+                        "type": "UnleashInstance_v1",
+                        "isList": true,
+                        "datafileSchema": "/app-sre/unleash-instance-1.yml"
+                    },
+                    {
+                        "name": "gabi_instances_v1",
+                        "type": "GabiInstance_v1",
+                        "isList": true,
+                        "datafileSchema": "/app-sre/gabi-instance-1.yml"
+                    },
+                    {
+                        "name": "template_tests_v1",
+                        "type": "TemplateTest_v1",
+                        "isList": true,
+                        "datafileSchema": "/app-interface/template-test-1.yml"
+                    },
+                    {
+                        "name": "dns_zone_v1",
+                        "type": "DnsZone_v1",
+                        "isList": true,
+                        "datafileSchema": "/dependencies/dns-zone-1.yml"
+                    },
+                    {
+                        "name": "slack_workspaces_v1",
+                        "type": "SlackWorkspace_v1",
+                        "isList": true,
+                        "datafileSchema": "/dependencies/slack-workspace-1.yml"
+                    },
+                    {
+                        "name": "ocp_release_mirror_v1",
+                        "type": "OcpReleaseMirror_v1",
+                        "isList": true,
+                        "datafileSchema": "/dependencies/ocp-release-mirror-1.yml"
+                    },
+                    {
+                        "name": "slo_document_v1",
+                        "type": "SLODocument_v1",
+                        "isList": true,
+                        "datafileSchema": "/app-sre/slo-document-1.yml"
+                    },
+                    {
+                        "name": "shared_resources_v1",
+                        "type": "SharedResources_v1",
+                        "isList": true,
+                        "datafileSchema": "/openshift/shared-resources-1.yml"
+                    },
+                    {
+                        "name": "pagerduty_instances_v1",
+                        "type": "PagerDutyInstance_v1",
+                        "isList": true,
+                        "datafileSchema": "/dependencies/pagerduty-instance-1.yml"
+                    },
+                    {
+                        "name": "ocm_instances_v1",
+                        "type": "OpenShiftClusterManager_v1",
+                        "isList": true,
+                        "datafileSchema": "/openshift/openshift-cluster-manager-1.yml"
+                    },
+                    {
+                        "name": "dyn_traffic_directors_v1",
+                        "type": "DynTrafficDirector_v1",
+                        "isList": true,
+                        "datafileSchema": "/dependencies/dyn-traffic-director-1.yml"
+                    },
+                    {
+                        "name": "status_page_v1",
+                        "type": "StatusPage_v1",
+                        "isList": true,
+                        "datafileSchema": "/dependencies/status-page-1.yml"
+                    },
+                    {
+                        "name": "status_page_component_v1",
+                        "type": "StatusPageComponent_v1",
+                        "isList": true,
+                        "datafileSchema": "/dependencies/status-page-component-1.yml"
+                    },
+                    {
+                        "name": "endpoint_monitoring_provider_v1",
+                        "type": "EndpointMonitoringProvider_v1",
+                        "isList": true,
+                        "isInterface": true,
+                        "datafileSchema": "/dependencies/endpoint-monitoring-provider-1.yml"
+                    }
+                ]
+            },
+            {
+                "name": "SentryTeam_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "instance",
+                        "type": "SentryInstance_v1",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "SentryRole_v1",
+                "fields": [
+                    {
+                        "name": "role",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "instance",
+                        "type": "SentryInstance_v1",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "SentryInstance_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "consoleUrl",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "automationToken",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "adminUser",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "SentryProjectItems_v1",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "email_prefix",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "platform",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "sensitive_fields",
+                        "type": "string",
+                        "isRequired": false,
+                        "isList": true
+                    },
+                    {
+                        "name": "safe_fields",
+                        "type": "string",
+                        "isRequired": false,
+                        "isList": true
+                    },
+                    {
+                        "name": "auto_resolve_age",
+                        "type": "int",
+                        "isRequired": false
+                    },
+                    {
+                        "name": "allowed_domains",
+                        "type": "string",
+                        "isRequired": false,
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "AppSentryProjects_v1",
+                "fields": [
+                    {
+                        "name": "team",
+                        "type": "SentryTeam_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "projects",
+                        "type": "SentryProjectItems_v1",
+                        "isRequired": true,
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "SqlEmailOverrides_v1",
+                "fields": [
+                    {
+                        "name": "db_host",
+                        "type": "string"
+                    },
+                    {
+                        "name": "db_port",
+                        "type": "string"
+                    },
+                    {
+                        "name": "db_name",
+                        "type": "string"
+                    },
+                    {
+                        "name": "db_user",
+                        "type": "string"
+                    },
+                    {
+                        "name": "db_password",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "DnsNamespaceZone_v1",
+                "fields": [
+                    {
+                        "name": "namespace",
+                        "type": "Namespace_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "DnsRecordHealthcheck_v1",
+                "fields": [
+                    {
+                        "name": "fqdn",
+                        "type": "string"
+                    },
+                    {
+                        "name": "port",
+                        "type": "int"
+                    },
+                    {
+                        "name": "type",
+                        "type": "string"
+                    },
+                    {
+                        "name": "resource_path",
+                        "type": "string"
+                    },
+                    {
+                        "name": "failure_threshold",
+                        "type": "int"
+                    },
+                    {
+                        "name": "request_interval",
+                        "type": "int"
+                    },
+                    {
+                        "name": "search_string",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "DnsRecordWeightedRoutingPolicy_v1",
+                "fields": [
+                    {
+                        "name": "weight",
+                        "type": "int"
+                    }
+                ]
+            },
+            {
+                "name": "DnsRecordAlias_v1",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "zone_id",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "evaluate_target_health",
+                        "type": "boolean",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "DnsRecord_v1",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "type",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "ttl",
+                        "type": "int"
+                    },
+                    {
+                        "name": "alias",
+                        "type": "DnsRecordAlias_v1"
+                    },
+                    {
+                        "name": "weighted_routing_policy",
+                        "type": "DnsRecordWeightedRoutingPolicy_v1"
+                    },
+                    {
+                        "name": "set_identifier",
+                        "type": "string"
+                    },
+                    {
+                        "name": "records",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "_healthcheck",
+                        "type": "DnsRecordHealthcheck_v1"
+                    },
+                    {
+                        "name": "_target_cluster",
+                        "type": "Cluster_v1"
+                    },
+                    {
+                        "name": "_target_namespace_zone",
+                        "type": "DnsNamespaceZone_v1"
+                    }
+                ]
+            },
+            {
+                "name": "DnsZone_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "account",
+                        "type": "AWSAccount_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "vpc",
+                        "type": "AWSVPC_v1"
+                    },
+                    {
+                        "name": "origin",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "unmanaged_record_names",
+                        "type": "string",
+                        "isList": true
+                    },
+                    {
+                        "name": "records",
+                        "type": "DnsRecord_v1",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "SLODocumentSLOSLOParameters_v1",
+                "fields": [
+                    {
+                        "name": "window",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "SLODocumentSLO_v1",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "SLIType",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "SLISpecification",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "SLODetails",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "SLOTarget",
+                        "type": "float",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "SLOParameters",
+                        "type": "SLODocumentSLOSLOParameters_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "expr",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "SLOTargetUnit",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "prometheusRules",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "prometheusRulesTests",
+                        "type": "string"
+                    },
+                    {
+                        "name": "dashboard",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "SLODocument_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "app",
+                        "type": "App_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "namespaces",
+                        "type": "Namespace_v1",
+                        "isList": true,
+                        "isRequired": true
+                    },
+                    {
+                        "name": "slos",
+                        "type": "SLODocumentSLO_v1",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "DynTrafficDirectorRecord_v1",
+                "fields": [
+                    {
+                        "name": "hostname",
+                        "type": "string"
+                    },
+                    {
+                        "name": "cluster",
+                        "type": "Cluster_v1"
+                    },
+                    {
+                        "name": "weight",
+                        "type": "int",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "DynTrafficDirector_v1",
+                "fields": [
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true,
+                        "isUnique": true
+                    },
+                    {
+                        "name": "ttl",
+                        "type": "int"
+                    },
+                    {
+                        "name": "records",
+                        "type": "DynTrafficDirectorRecord_v1",
+                        "isRequired": true,
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "StatusPage_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true,
+                        "isUnique": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "url",
+                        "type": "string"
+                    },
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "apiUrl",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "credentials",
+                        "type": "VaultSecret_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "pageId",
+                        "type": "string",
+                        "isRequired": true,
+                        "isUnique": true
+                    },
+                    {
+                        "name": "components",
+                        "type": "StatusPageComponent_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/dependencies/status-page-component-1.yml",
+                            "subAttr": "page"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "StatusPageComponent_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true,
+                        "isUnique": true
+                    },
+                    {
+                        "name": "displayName",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string"
+                    },
+                    {
+                        "name": "instructions",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "page",
+                        "type": "StatusPage_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "groupName",
+                        "type": "string"
+                    },
+                    {
+                        "name": "status",
+                        "type": "StatusProvider_v1",
+                        "isList": true,
+                        "isInterface": true
+                    },
+                    {
+                        "name": "apps",
+                        "type": "App_v1",
+                        "isList": true,
+                        "synthetic": {
+                            "schema": "/app-sre/app-1.yml",
+                            "subAttr": "statusPageComponents"
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "EndpointMonitoringProvider_v1",
+                "isInterface": true,
+                "interfaceResolve": {
+                    "strategy": "fieldMap",
+                    "field": "provider",
+                    "fieldMap": {
+                        "blackbox-exporter": "EndpointMonitoringProviderBlackboxExporter_v1",
+                        "signalfx": "EndpointMonitoringProviderSignalFx_v1"
+                    }
+                },
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true,
+                        "isUnique": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "metricLabels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "timeout",
+                        "type": "string"
+                    },
+                    {
+                        "name": "checkInterval",
+                        "type": "string"
+                    }
+                ]
+            },
+            {
+                "name": "EndpointMonitoringProviderBlackboxExporter_v1",
+                "interface": "EndpointMonitoringProvider_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true,
+                        "isUnique": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "metricLabels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "timeout",
+                        "type": "string"
+                    },
+                    {
+                        "name": "checkInterval",
+                        "type": "string"
+                    },
+                    {
+                        "name": "blackboxExporter",
+                        "type": "EndpointMonitoringProviderBlackboxExporterSettings_v1",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "EndpointMonitoringProviderBlackboxExporterSettings_v1",
+                "fields": [
+                    {
+                        "name": "module",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "namespace",
+                        "type": "Namespace_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "exporterUrl",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "EndpointMonitoringProviderSignalFx_v1",
+                "interface": "EndpointMonitoringProvider_v1",
+                "fields": [
+                    {
+                        "name": "schema",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "path",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "name",
+                        "type": "string",
+                        "isRequired": true,
+                        "isUnique": true
+                    },
+                    {
+                        "name": "description",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "metricLabels",
+                        "type": "json"
+                    },
+                    {
+                        "name": "timeout",
+                        "type": "string"
+                    },
+                    {
+                        "name": "checkInterval",
+                        "type": "string"
+                    },
+                    {
+                        "name": "signalFx",
+                        "type": "EndpointMonitoringProviderSignalFxSettings_v1",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "EndpointMonitoringProviderSignalFxSettings_v1",
+                "fields": [
+                    {
+                        "name": "namespace",
+                        "type": "Namespace_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "exporterUrl",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "targetFilterLabel",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "StatusProvider_v1",
+                "isInterface": true,
+                "interfaceResolve": {
+                    "strategy": "fieldMap",
+                    "field": "provider",
+                    "fieldMap": {
+                        "prometheus-alerts": "PrometheusAlertsStatusProvider_v1",
+                        "manual": "ManualStatusProvider_v1"
+                    }
+                },
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "PrometheusAlertsStatusProvider_v1",
+                "interface": "StatusProvider_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "prometheusAlerts",
+                        "type": "PrometheusAlertsStatusProviderConfig_v1",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "PrometheusAlertsStatusProviderConfig_v1",
+                "fields": [
+                    {
+                        "name": "namespace",
+                        "type": "Namespace_v1",
+                        "isList": true
+                    },
+                    {
+                        "name": "matchers",
+                        "type": "PrometheusAlertMatcher_v1",
+                        "isList": true
+                    }
+                ]
+            },
+            {
+                "name": "PrometheusAlertMatcher_v1",
+                "fields": [
+                    {
+                        "name": "matchExpression",
+                        "type": "PrometheusAlertMatcherExpression_v1",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "componentStatus",
+                        "type": "string",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "PrometheusAlertMatcherExpression_v1",
+                "fields": [
+                    {
+                        "name": "alert",
+                        "type": "string"
+                    },
+                    {
+                        "name": "labels",
+                        "type": "json"
+                    }
+                ]
+            },
+            {
+                "name": "ManualStatusProvider_v1",
+                "interface": "StatusProvider_v1",
+                "fields": [
+                    {
+                        "name": "provider",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "manual",
+                        "type": "ManualStatusProviderConfig_v1",
+                        "isRequired": true
+                    }
+                ]
+            },
+            {
+                "name": "ManualStatusProviderConfig_v1",
+                "fields": [
+                    {
+                        "name": "componentStatus",
+                        "type": "string",
+                        "isRequired": true
+                    },
+                    {
+                        "name": "from",
+                        "type": "string"
+                    },
+                    {
+                        "name": "until",
+                        "type": "string"
+                    }
+                ]
+            }
+        ]
+    },
     "data": {
         "/app-interface/app-interface-settings.yml": {
             "$schema": "/app-interface/app-interface-settings-1.yml",
@@ -20368,10 +21669,14 @@
             "settings": {
                 "config": {
                     "_type": "oidc",
+                    "default_role": "default",
                     "oidc_discovery_url": "http://localhost:8180/auth/realms/test",
                     "oidc_client_id": "vault",
-                    "oidc_client_secret": "my-special-client-secret",
-                    "default_role": "default"
+                    "oidc_client_secret_kv_version": "kv_v2",
+                    "oidc_client_secret": {
+                        "path": "secret/oidc",
+                        "field": "client-secret"
+                    }
                 }
             }
         },
@@ -20434,10 +21739,14 @@
             "settings": {
                 "config": {
                     "_type": "oidc",
+                    "default_role": "default",
                     "oidc_discovery_url": "http://localhost:8180/auth/realms/test",
                     "oidc_client_id": "vault",
-                    "oidc_client_secret": "my-special-client-secret",
-                    "default_role": "default"
+                    "oidc_client_secret_kv_version": "kv_v2",
+                    "oidc_client_secret": {
+                        "path": "secret/oidc",
+                        "field": "client-secret"
+                    }
                 }
             }
         },

--- a/tests/app-interface/data/services/vault/config/auth-backends/master/oidc.yml
+++ b/tests/app-interface/data/services/vault/config/auth-backends/master/oidc.yml
@@ -12,7 +12,10 @@ description: "rh sso auth backend"
 settings:
   config:
     _type: "oidc"
+    default_role: "default"
     oidc_discovery_url: "http://localhost:8180/auth/realms/test"
     oidc_client_id: "vault"
-    oidc_client_secret: "my-special-client-secret"
-    default_role: "default"
+    oidc_client_secret_kv_version: "kv_v2"
+    oidc_client_secret: 
+      path: "secret/oidc"
+      field: "client-secret"

--- a/tests/app-interface/data/services/vault/config/auth-backends/secondary/oidc.yml
+++ b/tests/app-interface/data/services/vault/config/auth-backends/secondary/oidc.yml
@@ -12,7 +12,10 @@ description: "rh sso auth backend"
 settings:
   config:
     _type: "oidc"
+    default_role: "default"
     oidc_discovery_url: "http://localhost:8180/auth/realms/test"
     oidc_client_id: "vault"
-    oidc_client_secret: "my-special-client-secret"
-    default_role: "default"
+    oidc_client_secret_kv_version: "kv_v2"
+    oidc_client_secret: 
+      path: "secret/oidc"
+      field: "client-secret"

--- a/tests/fixtures/auth/enable_auth_backends_with_policy_mappings.graphql
+++ b/tests/fixtures/auth/enable_auth_backends_with_policy_mappings.graphql
@@ -43,7 +43,6 @@
                 ... on VaultAuthConfigOidc_v1 {
                     oidc_discovery_url
                     oidc_client_id
-                    oidc_client_secret
                     default_role
                 }
             }

--- a/tests/fixtures/auth/enable_auth_backends_with_policy_mappings.graphql
+++ b/tests/fixtures/auth/enable_auth_backends_with_policy_mappings.graphql
@@ -44,6 +44,12 @@
                     oidc_discovery_url
                     oidc_client_id
                     default_role
+                    oidc_client_secret_kv_version
+                    oidc_client_secret {
+                      path
+                      field
+                      version
+                    }
                 }
             }
         }

--- a/tests/fixtures/roles/enable_vault_roles.graphql
+++ b/tests/fixtures/roles/enable_vault_roles.graphql
@@ -43,8 +43,13 @@
                 ... on VaultAuthConfigOidc_v1 {
                     oidc_discovery_url
                     oidc_client_id
-                    oidc_client_secret
                     default_role
+                    oidc_client_secret_kv_version
+                    oidc_client_secret {
+                      path
+                      field
+                      version
+                    }
                 }
             }
         }

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -96,6 +96,7 @@ container_alive "http://127.0.0.1:8200" $CONTAINER_HEALTH_TIMEOUT_DEFAULT $VAULT
 # populate necessary vault access vars to master
 vault kv put secret/master rootToken=root
 vault kv put secret/secondary root=root
+vault kv put secret/oidc client-secret=my-special-client-secret
 
 # spin up secondary vault server
 docker run -d --name=$VAULT_NAME_SECONDARY \
@@ -107,6 +108,11 @@ docker run -d --name=$VAULT_NAME_SECONDARY \
   -v /tmp/:/var/log/vault/:Z \
   $VAULT_IMAGE:$VAULT_IMAGE_TAG
 container_alive "http://127.0.0.1:8202" $CONTAINER_HEALTH_TIMEOUT_DEFAULT $VAULT_NAME_SECONDARY
+
+# populate oidc client secret in secondary
+export VAULT_ADDR=http://127.0.0.1:8202
+vault kv put secret/oidc client-secret=my-special-client-secret
+export VAULT_ADDR=http://127.0.0.1:8200
 
 # run test suite
 for test in $(find bats/ -type f | grep .bats | grep -v entities | grep -v groups); do

--- a/toplevel/auth/auth.go
+++ b/toplevel/auth/auth.go
@@ -32,11 +32,6 @@ type policyMapping struct {
 	Description string                   `yaml:"description"`
 }
 
-const (
-	OIDC_CLIENT_SECRET        = "oidc_client_secret"
-	OIDC_CLIENT_SECRET_KV_VER = "oidc_client_secret_kv_version"
-)
-
 var _ vault.Item = entry{}
 
 var _ vault.Item = policyMapping{}
@@ -340,13 +335,13 @@ func policyMappingsAsItems(xs []policyMapping) (items []vault.Item) {
 func getOidcClientSecret(instanceAddr string, settings map[string]map[string]interface{}) {
 	// logic to check existence of keys before referencing is unnecessary due to schema validation
 	cfg := settings["config"]
-	engineVersion := cfg[OIDC_CLIENT_SECRET_KV_VER].(string)
-	location := cfg[OIDC_CLIENT_SECRET].(map[interface{}]interface{})
+	engineVersion := cfg[vault.OIDC_CLIENT_SECRET_KV_VER].(string)
+	location := cfg[vault.OIDC_CLIENT_SECRET].(map[interface{}]interface{})
 	path := vault.FormatSecretPath(location["path"].(string), engineVersion)
 	field := location["field"].(string)
 	secret, err := vault.ProcessVaultCredential(path, field, engineVersion)
 	if err != nil {
 		log.WithError(err).Fatal("[Vault Auth] failed to retrieve `oidc_client_secret`")
 	}
-	cfg[OIDC_CLIENT_SECRET] = secret
+	cfg[vault.OIDC_CLIENT_SECRET] = secret
 }

--- a/toplevel/auth/auth.go
+++ b/toplevel/auth/auth.go
@@ -3,7 +3,6 @@
 package auth
 
 import (
-	"fmt"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -265,7 +264,6 @@ func configureAuthMounts(instanceAddr string, entries []entry, dryRun bool) {
 		if e.Settings != nil {
 			if e.Type == "oidc" {
 				getOidcClientSecret(instanceAddr, e.Settings)
-				fmt.Println(e.Settings)
 			}
 			for name, cfg := range e.Settings {
 				path := filepath.Join("auth", e.Path, name)
@@ -343,7 +341,7 @@ func getOidcClientSecret(instanceAddr string, settings map[string]map[string]int
 	// logic to check existence of keys before referencing is unnecessary due to schema validation
 	cfg := settings["config"]
 	engineVersion := cfg[OIDC_CLIENT_SECRET_KV_VER].(string)
-	location := cfg[OIDC_CLIENT_SECRET].(map[string]interface{})
+	location := cfg[OIDC_CLIENT_SECRET].(map[interface{}]interface{})
 	path := vault.FormatSecretPath(location["path"].(string), engineVersion)
 	field := location["field"].(string)
 	secret, err := vault.ProcessVaultCredential(path, field, engineVersion)

--- a/toplevel/instance/instance.go
+++ b/toplevel/instance/instance.go
@@ -79,14 +79,14 @@ func processInstances(instances []Instance) (map[string]vault.AuthBundle, error)
 				{
 					Name:    vault.ROLE_ID,
 					Type:    vault.APPROLE_AUTH,
-					Path:    formatSecretPath(i.Auth.RoleID.Path, i.Auth.SecretEngine),
+					Path:    vault.FormatSecretPath(i.Auth.RoleID.Path, i.Auth.SecretEngine),
 					Field:   i.Auth.RoleID.Field,
 					Version: i.Auth.RoleID.Version,
 				},
 				{
 					Name:    vault.SECRET_ID,
 					Type:    vault.APPROLE_AUTH,
-					Path:    formatSecretPath(i.Auth.SecretID.Path, i.Auth.SecretEngine),
+					Path:    vault.FormatSecretPath(i.Auth.SecretID.Path, i.Auth.SecretEngine),
 					Field:   i.Auth.SecretID.Field,
 					Version: i.Auth.SecretID.Version,
 				},
@@ -99,7 +99,7 @@ func processInstances(instances []Instance) (map[string]vault.AuthBundle, error)
 				{
 					Name:    vault.TOKEN,
 					Type:    vault.TOKEN_AUTH,
-					Path:    formatSecretPath(i.Auth.Token.Path, i.Auth.SecretEngine),
+					Path:    vault.FormatSecretPath(i.Auth.Token.Path, i.Auth.SecretEngine),
 					Field:   i.Auth.Token.Field,
 					Version: i.Auth.Token.Version,
 				},
@@ -112,18 +112,4 @@ func processInstances(instances []Instance) (map[string]vault.AuthBundle, error)
 	}
 
 	return instanceCreds, nil
-}
-
-// process secret path for kv v2
-// kv v2 api inserts /data/ between the root engine name and remaining path
-func formatSecretPath(secret string, secretEngine string) string {
-	if secretEngine == vault.KV_V2 {
-		sliced := strings.SplitN(secret, "/", 2)
-		if len(sliced) < 2 {
-			log.Fatal("[Vault Instance] Error processessing kv_v2 secret path")
-		}
-		return fmt.Sprintf("%s/data/%s", sliced[0], sliced[1])
-	} else {
-		return secret
-	}
 }

--- a/toplevel/role/role.go
+++ b/toplevel/role/role.go
@@ -140,7 +140,7 @@ func (c config) Apply(entriesBytes []byte, dryRun bool, threadPoolSize int) {
 									Name:    roles[i].(string),
 									Type:    existingAuthBackends[authBackend].Type,
 									Mount:   authBackend,
-									Options: vault.ReadSecret(instance, path).Data,
+									Options: vault.ReadSecret(instance, path, vault.KV_V1),
 								})
 
 							defer bwg.Done()


### PR DESCRIPTION
Note: change appears massive due to `data.json` update

SUMMARY
Refactor logic to process `oidc_client_secret` to support [update in q-schema](https://github.com/app-sre/qontract-schemas/pull/211). Addtionally, lead to refactor of `ReadSecret()`.

CONTEXT
`oidc_client_secret` was previously being pulled directly form the auth definition. This has been refactored to instead pull from a specified path/field within a Vault instance. In refactoring this logic, I realized `ReadSecret` was not accounting for KV version v2 (payload is slightly different). This was not an issue in the past as `ReadSecret` was only being utilized to pull internal configs (all of which utilize kv v1). However, to support the oidc change and future proof, this was refactored to support both KV versions.

ticket: https://issues.redhat.com/browse/APPSRE-6072