### PR TITLE
Refactor error handling (PART 1 - secret engine) - base logic

### DIFF
--- a/toplevel/auth/auth.go
+++ b/toplevel/auth/auth.go
@@ -3,6 +3,8 @@
 package auth
 
 import (
+	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -163,11 +165,11 @@ func (c config) Apply(entriesBytes []byte, dryRun bool, threadPoolSize int) {
 
 							policyMappingPath := filepath.Join("/auth/", e.Path, "map/teams", teams[team].(string))
 
-							policiesMappedToEntity := vault.ReadSecret(instanceAddr, policyMappingPath, vault.KV_V1)["value"].(string)
+							policiesMappedToEntity, _ := vault.ReadSecret(instanceAddr, policyMappingPath, vault.KV_V1)
 
 							policies := make([]map[string]interface{}, 0)
 
-							for _, policy := range strings.Split(policiesMappedToEntity, ",") {
+							for _, policy := range strings.Split(policiesMappedToEntity["value"].(string), ",") {
 								policies = append(policies, map[string]interface{}{"name": policy})
 							}
 
@@ -253,7 +255,7 @@ func enableAuth(instanceAddr string, toBeWritten []vault.Item, dryRun bool) {
 	}
 }
 
-func configureAuthMounts(instanceAddr string, entries []entry, dryRun bool) {
+func configureAuthMounts(instanceAddr string, entries []entry, dryRun bool) error {
 	// configure auth mounts
 	for _, e := range entries {
 		if e.Settings != nil {
@@ -262,7 +264,11 @@ func configureAuthMounts(instanceAddr string, entries []entry, dryRun bool) {
 			}
 			for name, cfg := range e.Settings {
 				path := filepath.Join("auth", e.Path, name)
-				if !vault.DataInSecret(instanceAddr, cfg, path) {
+				dataExists, err := vault.DataInSecret(instanceAddr, cfg, path)
+				if err != nil {
+					return err
+				}
+				if !dataExists {
 					if dryRun == true {
 						log.WithField("path", path).WithField("type", e.Type).WithField("instance", instanceAddr).Info(
 							"[Dry Run] [Vault Auth] auth backend configuration to be written")
@@ -275,6 +281,7 @@ func configureAuthMounts(instanceAddr string, entries []entry, dryRun bool) {
 			}
 		}
 	}
+	return nil
 }
 
 func disableAuth(instanceAddr string, toBeDeleted []vault.Item, dryRun bool) {
@@ -332,16 +339,19 @@ func policyMappingsAsItems(xs []policyMapping) (items []vault.Item) {
 }
 
 // retrieves client secret at vault location specified in oidc auth definition
-func getOidcClientSecret(instanceAddr string, settings map[string]map[string]interface{}) {
+func getOidcClientSecret(instanceAddr string, settings map[string]map[string]interface{}) error {
 	// logic to check existence of keys before referencing is unnecessary due to schema validation
 	cfg := settings["config"]
 	engineVersion := cfg[vault.OIDC_CLIENT_SECRET_KV_VER].(string)
 	location := cfg[vault.OIDC_CLIENT_SECRET].(map[interface{}]interface{})
 	path := vault.FormatSecretPath(location["path"].(string), engineVersion)
 	field := location["field"].(string)
-	secret, err := vault.ProcessVaultCredential(path, field, engineVersion)
+	secret, err := vault.GetVaultSecretField(instanceAddr, path, field, engineVersion)
 	if err != nil {
-		log.WithError(err).Fatal("[Vault Auth] failed to retrieve `oidc_client_secret`")
+		log.WithError(err)
+		return errors.New(fmt.Sprintf(
+			"[Vault Auth] failed to retrieve `oidc_client_secret` for %s", instanceAddr))
 	}
 	cfg[vault.OIDC_CLIENT_SECRET] = secret
+	return nil
 }

--- a/toplevel/secretsengine/secretsengine.go
+++ b/toplevel/secretsengine/secretsengine.go
@@ -66,10 +66,9 @@ func init() {
 	toplevel.RegisterConfiguration("vault_secret_engines", config{})
 }
 
+// TODO(dwelch) refactor into multiple functions
 // Apply ensures that an instance of Vault's secrets engine are configured
 // exactly as provided.
-//
-// This function exits the program if an error occurs.
 func (c config) Apply(entriesBytes []byte, dryRun bool, threadPoolSize int) {
 	// Unmarshal the list of configured secrets engines.
 	var entries []entry
@@ -82,8 +81,17 @@ func (c config) Apply(entriesBytes []byte, dryRun bool, threadPoolSize int) {
 	}
 
 	// perform reconcile operations for each instance
-	for _, instanceAddr := range instance.InstanceAddresses {
-		enabledSecretEngines := vault.ListSecretsEngines(instanceAddr)
+OUTER:
+	for instanceAddr := range vault.InstanceAddresses {
+		enabledSecretEngines, err := vault.ListSecretsEngines(instanceAddr)
+		if err != nil {
+			log.WithError(err).WithFields(log.Fields{
+				"instance": instanceAddr,
+			}).Info("[Vault Secret Engine] failed to list existing secret engines")
+			vault.AddInvalid(instanceAddr)
+			continue
+		}
+
 		existingSecretEngines := []entry{}
 		for path, engine := range enabledSecretEngines {
 			existingSecretEngines = append(existingSecretEngines, entry{
@@ -124,11 +132,19 @@ func (c config) Apply(entriesBytes []byte, dryRun bool, threadPoolSize int) {
 			// TODO(riuvshin): implement tuning
 			for _, e := range toBeWritten {
 				ent := e.(entry)
-				vault.EnableSecretsEngine(instanceAddr, ent.Path, &api.MountInput{
+				err := vault.EnableSecretsEngine(instanceAddr, ent.Path, &api.MountInput{
 					Type:        ent.Type,
 					Description: ent.Description,
 					Options:     ent.Options,
 				})
+				if err != nil {
+					log.WithError(err).WithFields(log.Fields{
+						"instance": instanceAddr,
+						"type":     e.(entry).Type,
+					}).Info("[Vault Secret Engine] failed to enable secret engine")
+					vault.AddInvalid(instanceAddr)
+					continue OUTER
+				}
 			}
 
 			for _, e := range toBeUpdated {
@@ -137,16 +153,35 @@ func (c config) Apply(entriesBytes []byte, dryRun bool, threadPoolSize int) {
 					// vault.UpdateSecretsEngine(ent.Path, &api.MountInput{
 					Description: &ent.Description,
 				})
+				if err != nil {
+					log.WithError(err).WithFields(log.Fields{
+						"instance": instanceAddr,
+						"type":     e.(entry).Type,
+					}).Info("[Vault Secret Engine] failed to update secret engine")
+					vault.AddInvalid(instanceAddr)
+					continue OUTER
+				}
 			}
 
 			for _, e := range toBeDeleted {
 				ent := e.(entry)
 				if !isDefaultMount(ent.Path) {
-					vault.DisableSecretsEngine(instanceAddr, ent.Path)
+					err := vault.DisableSecretsEngine(instanceAddr, ent.Path)
+					if err != nil {
+						log.WithError(err).WithFields(log.Fields{
+							"instance": instanceAddr,
+							"type":     e.(entry).Type,
+						}).Info("[Vault Secret Engine] failed to disable secret engine")
+						vault.AddInvalid(instanceAddr)
+						continue OUTER
+					}
 				}
 			}
 		}
 	}
+	// removes instances that generated errors from remaining reconciliation process
+	// this is necessary due to dependencies between toplevels
+	vault.RemoveInstanceFromReconciliation()
 }
 
 func isDefaultMount(path string) bool {

--- a/toplevel/secretsengine/secretsengine.go
+++ b/toplevel/secretsengine/secretsengine.go
@@ -85,9 +85,6 @@ OUTER:
 	for instanceAddr := range vault.InstanceAddresses {
 		enabledSecretEngines, err := vault.ListSecretsEngines(instanceAddr)
 		if err != nil {
-			log.WithError(err).WithFields(log.Fields{
-				"instance": instanceAddr,
-			}).Info("[Vault Secret Engine] failed to list existing secret engines")
 			vault.AddInvalid(instanceAddr)
 			continue
 		}
@@ -138,10 +135,6 @@ OUTER:
 					Options:     ent.Options,
 				})
 				if err != nil {
-					log.WithError(err).WithFields(log.Fields{
-						"instance": instanceAddr,
-						"type":     e.(entry).Type,
-					}).Info("[Vault Secret Engine] failed to enable secret engine")
 					vault.AddInvalid(instanceAddr)
 					continue OUTER
 				}
@@ -154,10 +147,6 @@ OUTER:
 					Description: &ent.Description,
 				})
 				if err != nil {
-					log.WithError(err).WithFields(log.Fields{
-						"instance": instanceAddr,
-						"type":     e.(entry).Type,
-					}).Info("[Vault Secret Engine] failed to update secret engine")
 					vault.AddInvalid(instanceAddr)
 					continue OUTER
 				}
@@ -168,10 +157,6 @@ OUTER:
 				if !isDefaultMount(ent.Path) {
 					err := vault.DisableSecretsEngine(instanceAddr, ent.Path)
 					if err != nil {
-						log.WithError(err).WithFields(log.Fields{
-							"instance": instanceAddr,
-							"type":     e.(entry).Type,
-						}).Info("[Vault Secret Engine] failed to disable secret engine")
 						vault.AddInvalid(instanceAddr)
 						continue OUTER
 					}


### PR DESCRIPTION
This is part of effort to segment original PR (https://github.com/app-sre/vault-manager/pull/58) into more review friendly portions.

Major design change being implemented by refactor is within `client.go`. Specifically, the addition of global vars `InstanceAddresses` and `invalidInstances`, as well as the functions `AddInvalid` and `RemoveInstanceFromReconciliation`. The function calls will be seen throughout toplevels in this PR and proceeding. 

CONTEXT
`Fatal` was used liberally in the original design of vault manager (i.e before mutli instance support existed). This made sense because many resource types are dependent on one another. For example, if an error occurs while creating a policy, the easy/safe solution is to terminate the program because that role may have been a dependency later in the reconcile process by role, auth, etc.

With multi instance support, this "default to fatal" design is no longer viable. An error occurring while configuring a policy for one instance should not affect another instance's ability to reconcile.

At high level, this refactor allows toplevels to handle errors at a per instance level. If an error occurs while configuring an instance's policies, instead of fatally exiting, a call to `AddInvalid` is made and the rest of toplevel logic is skipped. Before the toplevel exits, it will call `RemoveInstanceFromReconciliation`, this function checks the global `invalidInstances` (updated by calls to `AddInvalid`) and removes any instances from the global `InstanceAddresses`. `InstanceAddresses` is referenced within every top level and drives what instances are targeted for reconciliation. I.E the proceeding toplevels will iterate over an updated version of `InstanceAddresses` that no longer includes the instance that caused an error.

Primary toplevel refactored: secret engine

In refactoring secret engine, adjustments were required within auth and role toplevels, as they share usage with vault package. Full refactor of these toplevels will be saved for follow up PRs.

Refer to https://github.com/app-sre/vault-manager/pull/68 for addition of tests that validate the overall refactor initiative.