### PR TITLE
Group update bug fix

### DIFF
--- a/cmd/vault-manager/main.go
+++ b/cmd/vault-manager/main.go
@@ -67,7 +67,7 @@ func main() {
 	instanceAddresses := initInstances(cfg, threadPoolSize)
 
 	// remove disabled toplevels
-	if _, set := os.LookupEnv("DISABLE_IDENTITY"); set {
+	if disabled, _ := os.LookupEnv("DISABLE_IDENTITY"); disabled == "true" {
 		delete(cfg, "vault_entities")
 		delete(cfg, "vault_groups")
 	}


### PR DESCRIPTION
When a role references multiple oidc permissions, existing logic adds the user who references the role for each permission. This leads to vault-manager attempting to update the afflicted group on each iteration because it tries to apply duplicate entity IDs.