### PR TITLE
fix counter metric name

### DIFF
--- a/openshift/vault-manager.template.yaml
+++ b/openshift/vault-manager.template.yaml
@@ -100,7 +100,7 @@ parameters:
   displayName: vault-manager version
   description: vault-manager version which defaults to latest
 - name: MEMORY_REQUESTS
-  value: 100Mi
+  value: 150Mi
 - name: MEMORY_LIMIT
   value: 250Mi
 - name: CPU_REQUESTS

--- a/pkg/utils/metrics.go
+++ b/pkg/utils/metrics.go
@@ -9,7 +9,7 @@ import (
 var (
 	reconcileSuccessCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "qontract_reconcile_execution_counter",
+			Name: "qontract_reconcile_execution_counter_total",
 			Help: "Increment by one for each successful reconcile. Used to alert on 'stuck' instance reconciles",
 		},
 		[]string{


### PR DESCRIPTION
existing name is different from metric name used in qontract reconcile alerting rules