### PR TITLE
refactor to use more intuitive root `/`

### DIFF
--- a/tests/app-interface/data/services/vault/config/roles/master/approles/vault-manager.yml
+++ b/tests/app-interface/data/services/vault/config/roles/master/approles/vault-manager.yml
@@ -9,7 +9,7 @@ type: "approle"
 mount: "approle/"
 instance:
   $ref: /services/vault/config/instances/master.yml
-output_path: app-interface/vault-manager-approle
+output_path: /app-interface/vault-manager-approle
 options:
   _type: "approle"
   bind_secret_id: "true"

--- a/tests/app-interface/data/services/vault/config/roles/secondary/approles/app-interface.yml
+++ b/tests/app-interface/data/services/vault/config/roles/secondary/approles/app-interface.yml
@@ -9,7 +9,7 @@ type: "approle"
 mount: "approle/"
 instance:
   $ref: /services/vault/config/instances/secondary.yml
-output_path: app-interface/app-interface-approle
+output_path: /app-interface/app-interface-approle
 options:
   _type: "approle"
   bind_secret_id: "true"


### PR DESCRIPTION
Encountered issue with tenants that were including `/` at the base of their desired `output_path`s. This was throwing an error with existing implementation. But in retrospect, inclusion of the initial `/` is more intuitive. This MR refactors logic to accept this format