### PR TITLE
Implement liveness probe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,5 +5,5 @@ RUN make gobuild
 FROM registry.access.redhat.com/ubi8-minimal:8.2
 RUN microdnf update -y && microdnf install -y ca-certificates && rm -rf /var/cache/yum
 COPY --from=builder /opt/app-root/src/vault-manager /
-COPY query.graphql /
+COPY query.graphql liveness.sh /
 ENTRYPOINT ["/vault-manager"]

--- a/cmd/vault-manager/main.go
+++ b/cmd/vault-manager/main.go
@@ -65,6 +65,7 @@ func main() {
 	flag.Parse()
 
 	var sleepDuration time.Duration
+	var livenessFile string
 	if !runOnce {
 		// configure sleep duration
 		sleep, _ := os.LookupEnv("RECONCILE_SLEEP_TIME")
@@ -76,6 +77,11 @@ func main() {
 			log.Fatalln(err)
 		}
 		sleepDuration = sleepDur
+
+		livenessFile, _ = os.LookupEnv("LIVENESS_PROBE_FILE")
+		if livenessFile == "" {
+			log.Fatalln("`LIVENESS_PROBE_FILE` must be set when `run-once` flag is false")
+		}
 
 		// configure prometheus metrics handler
 		port, _ := os.LookupEnv("METRICS_SERVER_PORT")
@@ -137,6 +143,7 @@ func main() {
 
 			if !runOnce {
 				utils.RecordMetrics(address, status, time.Since(start))
+				utils.UpdateSwitch(livenessFile)
 			}
 		}
 

--- a/liveness.sh
+++ b/liveness.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+source "$1"
+
+if [[ "$VALUE" != "0" ]]
+then
+    exit 1
+fi
+
+# set back for app to update
+echo "VALUE=1" > "$1"
+exit 0

--- a/openshift/vault-manager.template.yaml
+++ b/openshift/vault-manager.template.yaml
@@ -90,14 +90,14 @@ objects:
               memory: ${MEMORY_LIMIT}
               cpu: ${CPU_LIMIT}
           livenessProbe:
-            httpGet:
-              path: /metrics
-              port: ${METRICS_SERVER_PORT}
-              scheme: HTTP
-            failureThreshold: 3
-            periodSeconds: 10
+            exec:
+            - /bin/bash
+            - /liveness.sh
+            - ${LIVENESS_PROBE_FILE}
+            initialDelaySeconds: 60
+            periodSeconds: ${LIVENESS_PROBE_PERIOD_SECONDS}
+            failureThreshold: 2
             successThreshold: 1
-            initialDelaySeconds: 10
 parameters:
 - name: IMAGE
   value: quay.io/app-sre/vault-manager
@@ -119,6 +119,10 @@ parameters:
   value: '3'
 - name: RECONCILE_SLEEP_TIME
   value: '15m'
+- name: LIVENESS_PROBE_FILE
+  value: '/switch.txt'
+- name: LIVENESS_PROBE_PERIOD_SECONDS
+  value: '900'
 - name: DRY_RUN
   description: runs vault-manager in dry-run mode when true
   value: 'false'

--- a/openshift/vault-manager.template.yaml
+++ b/openshift/vault-manager.template.yaml
@@ -89,6 +89,15 @@ objects:
             limits:
               memory: ${MEMORY_LIMIT}
               cpu: ${CPU_LIMIT}
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: ${METRICS_SERVER_PORT}
+              scheme: HTTP
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+            initialDelaySeconds: 10
 parameters:
 - name: IMAGE
   value: quay.io/app-sre/vault-manager

--- a/pkg/utils/metrics.go
+++ b/pkg/utils/metrics.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"log"
+	"os"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -70,4 +72,15 @@ func RecordMetrics(instance string, status int, duration time.Duration) {
 			"shard_id":    instance,
 			"integration": INTEGRATION,
 		}).Set(duration.Seconds())
+}
+
+// UpdateSwitch supports liveness probe check
+func UpdateSwitch(livenessFile string) {
+	f, err := os.OpenFile(livenessFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+
+	f.Write([]byte("VALUE=0"))
 }


### PR DESCRIPTION
Implements liveness probe in form of script that checks for a specific value within a file. 

App logic has been added to set the value within specified file to `0` after each successful reconcile run. The liveness probe script checks if existing value equals `0` and exits in failure if not. If successful, the script sets the file value to `1` and exists successfully.

`periodSeconds` on liveness probe must be >= `RECONCILE_SLEEP_TIME`. New var `LIVENESS_PROBE_PERIOD_SECONDS` was added to template because Go's time package cannot parse times without suffix (m, s, h, etc). But the `periodSeconds` value should not contain such suffixes.