### PR TITLE
refactor graphql query to utilize timeout

### DIFF
--- a/cmd/vault-manager/main.go
+++ b/cmd/vault-manager/main.go
@@ -182,13 +182,13 @@ func getConfig() (config, error) {
 		req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(graphqlUsername+":"+graphqlPassword)))
 	}
 
-	// define a Context for the request
-	ctx := context.Background()
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
 
 	var response map[string]interface{}
 
 	// execute query and capture the response
-	if err := client.Run(ctx, req, &response); err != nil {
+	if err := client.Run(ctxTimeout, req, &response); err != nil {
 		return config{}, errors.Wrap(err, "failed to query graphql server")
 	}
 

--- a/cmd/vault-manager/main.go
+++ b/cmd/vault-manager/main.go
@@ -182,7 +182,7 @@ func getConfig() (config, error) {
 		req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(graphqlUsername+":"+graphqlPassword)))
 	}
 
-	ctxTimeout, cancel := context.WithTimeout(context.Background(), time.Second*6)
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 
 	var response map[string]interface{}

--- a/cmd/vault-manager/main.go
+++ b/cmd/vault-manager/main.go
@@ -182,7 +182,7 @@ func getConfig() (config, error) {
 		req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(graphqlUsername+":"+graphqlPassword)))
 	}
 
-	ctxTimeout, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), time.Second*6)
 	defer cancel()
 
 	var response map[string]interface{}


### PR DESCRIPTION
There have been serveral occurrences over the past ~30 days where vault manager entered a "stuck" state. In reviewing logs, it was identified that network communication had failed when performing the graphql query at roughly the beginning of each "stuck" state. This MR attempts to resolve this stuck behavior by creating a timeout for the graphql request.