### PR TITLE
utilize same rationale as qr for ignoring liveness check

### DIFF
--- a/openshift/vault-manager.template.yaml
+++ b/openshift/vault-manager.template.yaml
@@ -15,6 +15,7 @@ objects:
     annotations:
       ignore-check.kube-linter.io/minimum-three-replicas: "vault-manager design does not adequately account for multiple replicas"
       ignore-check.kube-linter.io/no-readiness-probe: "vault-manager is not getting traffic"
+      ignore-check.kube-linter.io/no-liveness-probe: "vault-manager is monitored for being stuck"
     name: vault-manager
   spec:
     replicas: ${{REPLICAS}}


### PR DESCRIPTION
Efforts have been made for vault manager to export the same metrics / execute in the same way as [qontract reconcile](https://github.com/app-sre/qontract-reconcile) integrations. The [same reasoning](https://github.com/app-sre/qontract-reconcile/blob/master/openshift/qontract-manager.yaml#L16) for ignoring liveness probe check on qr integrations will be utilized here.