### PR TITLE
Revert graphql refactor

### DIFF
--- a/cmd/vault-manager/main.go
+++ b/cmd/vault-manager/main.go
@@ -201,13 +201,13 @@ func getConfig() (config, error) {
 		req.Header.Set("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(graphqlUsername+":"+graphqlPassword)))
 	}
 
-	ctxTimeout, cancel := context.WithTimeout(context.Background(), time.Second*10)
-	defer cancel()
+	// define a Context for the request
+	ctx := context.Background()
 
 	var response map[string]interface{}
 
 	// execute query and capture the response
-	if err := client.Run(ctxTimeout, req, &response); err != nil {
+	if err := client.Run(ctx, req, &response); err != nil {
 		return config{}, errors.Wrap(err, "failed to query graphql server")
 	}
 


### PR DESCRIPTION
Investigation still required as to why refactor was causing more frequent failures within pr check due to context deadline exceeds.