### PR TITLE
[local dev] Audit log permission fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.dll
 *.so
 *.dylib
+vault-manager
+
 
 # Test binary, build with `go test -c`
 *.test


### PR DESCRIPTION
The Vault container runs as the user `vault` [ref](https://github.com/hashicorp/docker-vault/blob/master/0.X/Dockerfile), however the `/var/log` directory is owned by `root`. Therefore, when trying to spin up a local environment, you will run into an issue where Vault can't write audit logs to `/var/log/vault`.

`level=info msg="[Vault Audit] failed to enable audit device" error="Error making API request.\n\nURL: PUT http://127.0.0.1:8200/v1/sys/audit/file\nCode: 400. Errors:\n\n* sanity check failed; unable to open \"/var/log/vault/vault_audit.log\" for writing: open /var/log/vault/vault_audit.log: permission denied" instance="http://127.0.0.1:8200" path=file/
`

This MR updates the local dev shell script to create that new folder and give the `vault` user permissions. It also removes the container mount from host to the vault containers and updates the .gitignore so that we don't upload the actual vault-manager binary to Git.