### PR TITLE
APPSRE-6669 - Add ability for vault manager to output affected entities of permission changes in pr checks

### DIFF
--- a/.env
+++ b/.env
@@ -31,7 +31,7 @@ export VALIDATOR_IMAGE_TAG=f412923
 
 # used to generate data.json via make bundle in tests/app-interface/Makefile
 export SCHEMAS_IMAGE=quay.io/app-sre/qontract-schemas
-export SCHEMAS_IMAGE_TAG=9bf4e22
+export SCHEMAS_IMAGE_TAG=a2f36d3
 
 # used for testing. referenced in cmd/vault-manager/main.go
 export GRAPHQL_SERVER=http://127.0.0.1:4000/graphql

--- a/cmd/vault-manager/main.go
+++ b/cmd/vault-manager/main.go
@@ -50,7 +50,7 @@ func init() {
 	if logFileLocation == "" {
 		log.SetOutput(os.Stdout)
 	} else {
-                var err error
+		var err error
 		logFile, err = os.Create(logFileLocation)
 		if err != nil {
 			log.SetOutput(os.Stdout)
@@ -157,6 +157,7 @@ func main() {
 			if !runOnce {
 				utils.RecordMetrics(address, status, time.Since(start))
 			}
+			toplevel.ClearPolicies()
 		}
 
 		if runOnce {

--- a/tests/bats/groups/groups.bats
+++ b/tests/bats/groups/groups.bats
@@ -74,7 +74,7 @@ load ../helpers
     [ "$status" -eq 0 ]
 
     [[ "${output}" == *"[Dry Run] [Vault Identity] 1 user(s) in group: 'app-sre-vault-oidc' will have policy: 'vault-oidc-app-sre-policy' updated"*"action=updated"*"group=app-sre-vault-oidc"*"instance=\"http://127.0.0.1:8200\""*"policy=vault-oidc-app-sre-policy"* ]]
-    [[ "${output}" == *"[Dry Run] [Vault Identity] 1 user(s) in group: 'app-interface-vault-oidc' will have policy: 'vault-oidc-app-sre-policy' updated"*"action=updated"*"group=app-sre-vault-oidc"*"instance=\"http://127.0.0.1:8200\""*"policy=vault-oidc-app-sre-policy"* ]]
+    [[ "${output}" == *"[Dry Run] [Vault Identity] 1 user(s) in group: 'app-interface-vault-oidc' will have policy: 'vault-oidc-app-sre-policy' updated"*"action=updated"*"group=app-interface-vault-oidc"*"instance=\"http://127.0.0.1:8200\""*"policy=vault-oidc-app-sre-policy"* ]]
 
     # cleanup afterwards
     run vault-manager

--- a/tests/fixtures/groups/vault-oidc-app-sre-policy.hcl
+++ b/tests/fixtures/groups/vault-oidc-app-sre-policy.hcl
@@ -1,0 +1,20 @@
+
+path "app-sre/*" {
+    capabilities = ["create", "read", "update", "delete", "list"]
+}
+path "app-interface/*" {
+    capabilities = ["create", "read", "update", "delete", "list"]
+}
+
+# https://www.vaultproject.io/api/system/audit-hash#calculate-hash
+path "/sys/audit-hash/file" {
+    capabilities = ["create", "read", "update"]
+}
+
+#allow vault seal/unseal
+path "/sys/seal" {
+    policy = "sudo"
+}
+path "/sys/unseal" {
+    policy = "sudo"
+}

--- a/tests/fixtures/groups/vault_groups_and_policies.graphql
+++ b/tests/fixtures/groups/vault_groups_and_policies.graphql
@@ -1,0 +1,54 @@
+{
+  vault_instances: vault_instances_v1 {
+    address
+    auth {
+      secretEngine
+      provider
+      ... on VaultInstanceAuthApprole_v1 {
+        roleID {
+          path
+          field
+          version
+        }
+        secretID {
+          path
+          field
+          version
+        }
+      }
+      ... on VaultInstanceAuthToken_v1 {
+        token {
+          path
+          field
+          version
+        }
+      }
+    }
+  }
+  vault_groups: users_v1 {
+    org_username
+    roles {
+      name
+      oidc_permissions {
+        name
+        description
+        service
+        ... on OidcPermissionVault_v1 {
+          vault_policies {
+            name
+          }
+          instance {
+            address
+          }
+        }
+      }
+    }
+  }
+  vault_policies: vault_policies_v1 {
+        name
+        rules
+        instance {
+            address
+        }
+    }
+}

--- a/toplevel/group/group.go
+++ b/toplevel/group/group.go
@@ -439,9 +439,10 @@ func outputPolicyAffectedGroups(desired []group) {
 				action := toplevel.PrintPolicyAction(action)
 				// this group will be affected by the policy change
 				log.WithFields(log.Fields{
-					"policy": p,
-					"group":  d.Name,
-					"action": action,
+					"policy":   p,
+					"group":    d.Name,
+					"action":   action,
+					"instance": d.Instance.Address,
 				}).Infof("[Dry Run] [Vault Identity] %d user(s) in group: '%s' will have policy: '%s' %s", len(d.EntityIds), d.Name, p, action)
 			}
 		}
@@ -451,15 +452,6 @@ func outputPolicyAffectedGroups(desired []group) {
 // Compare existing and desired groups to determine who is affected by policy additions and removals
 // existing and desired should be sorted
 func outputGroupsWithPolicyChanges(existing []group, desired []group) {
-	// what do i want to do here
-	// step one is compare existing and desired groups
-	// if i find a match between group names then i want to compare policies between them
-
-	// what groups and thus policies are being added
-	//	anything that's not in existing but is in desired
-	// what groups and thus policies are being removed
-	//	anything that's in existing but not in desired
-
 	existingMap := groupToMap(existing)
 	desiredMap := groupToMap(desired)
 

--- a/toplevel/group/group.go
+++ b/toplevel/group/group.go
@@ -432,7 +432,7 @@ func dryRunOutput(instanceAddr string, groups []vault.Item, action string) {
 func outputPolicyAffectedGroups(desired []group) {
 	policyActions := toplevel.GetPolicies()
 
-	if len(policyActions) > 0 {
+	if len(policyActions) == 0 {
 		return
 	}
 

--- a/toplevel/group/group.go
+++ b/toplevel/group/group.go
@@ -432,6 +432,10 @@ func dryRunOutput(instanceAddr string, groups []vault.Item, action string) {
 func outputPolicyAffectedGroups(desired []group) {
 	policyActions := toplevel.GetPolicies()
 
+	if len(policyActions) > 0 {
+		return
+	}
+
 	for _, d := range desired {
 		for _, p := range d.Policies {
 			action, ok := policyActions[p]

--- a/toplevel/policy/policy.go
+++ b/toplevel/policy/policy.go
@@ -119,6 +119,7 @@ func (c config) Apply(address string, entriesBytes []byte, dryRun bool, threadPo
 			}
 			log.WithField("instance", address).Infof("[Dry Run] [Vault Policy] policy to be deleted='%v'", d.Key())
 		}
+		toplevel.UpdatePolicies(toBeWritten, toBeDeleted)
 	} else {
 		// Write any missing policies to the Vault instance.
 		for _, e := range toBeWritten {

--- a/toplevel/toplevel.go
+++ b/toplevel/toplevel.go
@@ -88,3 +88,14 @@ func GetPolicies() map[string]PolicyAction {
 func ClearPolicies() {
 	policyActions = make(map[string]PolicyAction)
 }
+
+// Output policy actions in string format
+func PrintPolicyAction(policyAction PolicyAction) string {
+	switch policyAction {
+	case Write:
+		return "added"
+	case Delete:
+		return "removed"
+	}
+	return "invalid"
+}

--- a/toplevel/toplevel.go
+++ b/toplevel/toplevel.go
@@ -93,7 +93,7 @@ func ClearPolicies() {
 func PrintPolicyAction(policyAction PolicyAction) string {
 	switch policyAction {
 	case Write:
-		return "added"
+		return "updated"
 	case Delete:
 		return "removed"
 	}

--- a/toplevel/toplevel.go
+++ b/toplevel/toplevel.go
@@ -6,12 +6,21 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/app-sre/vault-manager/pkg/vault"
 	log "github.com/sirupsen/logrus"
 )
 
+type PolicyAction int
+
+const (
+	Write = iota
+	Delete
+)
+
 var (
-	configs  = make(map[string]Configuration)
-	configsM sync.RWMutex
+	configs       = make(map[string]Configuration)
+	configsM      sync.RWMutex
+	policyActions = make(map[string]PolicyAction)
 )
 
 // Configuration represents a block of declarative configuration data that can
@@ -57,4 +66,25 @@ func Apply(name string, address string, cfg []byte, dryRun bool, threadPoolSize 
 		log.WithField("name", name).Fatal("failed to find top-level configuration")
 	}
 	return c.Apply(address, cfg, dryRun, threadPoolSize)
+}
+
+// Update package level policies which are to be written or deleted
+func UpdatePolicies(toBeWritten []vault.Item, toBeDeleted []vault.Item) {
+	for _, w := range toBeWritten {
+		policyActions[w.Key()] = Write
+	}
+
+	for _, d := range toBeDeleted {
+		policyActions[d.Key()] = Delete
+	}
+}
+
+// Return the list of policy actions
+func GetPolicies() map[string]PolicyAction {
+	return policyActions
+}
+
+// Clear list of policy actions
+func ClearPolicies() {
+	policyActions = make(map[string]PolicyAction)
 }


### PR DESCRIPTION
[APPSRE-6669](https://issues.redhat.com/browse/APPSRE-6669)

Adds more detailed and readable output during pr-checks of Vault Manager. When the dry-run flag is enabled, vault-manager will add more detailed output during the following cases:

## Policy added/removed from OIDC permission or a permission is added/removed from a role

The output is listing the groups in Vault which will be affected by this change as well as the number of users in each group. Additionally, the policies which are added/removed are listed in the output.
```
level=info msg="[Dry Run] The group 'app-sre-vault-oidc' will have policy changes which will affect 1 user(s)" addedPolicies="[app-sre-policy]" group=app-sre-vault-oidc removedPolicies="[vault-oidc-app-sre-policy]"
level=info msg="[Dry Run] The group 'app-interface-vault-oidc' will have policy changes which will affect 1 user(s)" addedPolicies="[app-sre-policy]" group=app-interface-vault-oidc removedPolicies="[vault-oidc-app-sre-policy]"
```

## A policy is updated directly
A count of users and groups that are affected by the change are listed.
```
level=info msg="[Dry Run] 1 user(s) in this group will be affected by this change" action=0 group=app-sre-vault-oidc policy=vault-oidc-app-sre-policy
level=info msg="[Dry Run] 1 user(s) in this group will be affected by this change" action=0 group=app-interface-vault-oidc policy=vault-oidc-app-sre-policy
```

Testing has been added to the BATs suite to ensure it outputs as expected.