### PR TITLE
refactor optional kube auth

### DIFF
--- a/cmd/vault-manager/main.go
+++ b/cmd/vault-manager/main.go
@@ -120,12 +120,6 @@ func main() {
 		// initialize vault clients and gather list of instance addresses for reconciliation
 		instanceAddresses := initInstances(cfg, kubeAuth, threadPoolSize)
 
-		// remove disabled toplevels
-		if disabled, _ := os.LookupEnv("DISABLE_IDENTITY"); disabled == "true" {
-			delete(cfg, "vault_entities")
-			delete(cfg, "vault_groups")
-		}
-
 		topLevelConfigs := []TopLevelConfig{}
 
 		for key := range cfg {

--- a/cmd/vault-manager/main.go
+++ b/cmd/vault-manager/main.go
@@ -76,11 +76,13 @@ func main() {
 
 	var dryRun bool
 	var runOnce bool
+	var kubeAuth bool
 	var threadPoolSize int
 	flag.BoolVar(&dryRun, "dry-run", false, "If true, will only print planned actions")
 	flag.IntVar(&threadPoolSize, "thread-pool-size", 10, "Some operations are running in parallel"+
 		" to achieve the best performance, so -thread-pool-size determine how many threads can be utilized, default is 10")
 	flag.BoolVar(&runOnce, "run-once", true, "If true, program will skip loop and exit after first reconcile attempt")
+	flag.BoolVar(&kubeAuth, "kube-auth", false, "If true, will attempt to utilize kubernetes authentication where applicable")
 	flag.Parse()
 
 	var sleepDuration time.Duration
@@ -116,7 +118,7 @@ func main() {
 		}
 
 		// initialize vault clients and gather list of instance addresses for reconciliation
-		instanceAddresses := initInstances(cfg, threadPoolSize)
+		instanceAddresses := initInstances(cfg, kubeAuth, threadPoolSize)
 
 		// remove disabled toplevels
 		if disabled, _ := os.LookupEnv("DISABLE_IDENTITY"); disabled == "true" {
@@ -218,7 +220,7 @@ func getConfig() (config, error) {
 // gathers instances referenced across all applicable file definitions and initializes the clients
 // clients are set as private global witihn client.go
 // return is list of strings containing addresses of vault instances
-func initInstances(cfg config, threadPoolSize int) []string {
+func initInstances(cfg config, kubeAuth bool, threadPoolSize int) []string {
 	const INSTANCE_KEY = "vault_instances"
 	dataBytes, err := yaml.Marshal(cfg[INSTANCE_KEY])
 	if err != nil {
@@ -226,7 +228,7 @@ func initInstances(cfg config, threadPoolSize int) []string {
 	}
 	// do not include `vault_instances` in standard top-level reconcile loop
 	delete(cfg, INSTANCE_KEY)
-	return vault.GetInstances(dataBytes, threadPoolSize)
+	return vault.GetInstances(dataBytes, kubeAuth, threadPoolSize)
 }
 
 func resolveConfigPriority(s string) int {

--- a/helm/vault-manager/templates/template.yaml
+++ b/helm/vault-manager/templates/template.yaml
@@ -125,7 +125,7 @@ objects:
           command: ["/bin/sh"]
           args: 
           - "-c"
-          - "/vault-manager -dry-run=${DRY_RUN} -run-once=${RUN_ONCE} -thread-pool-size=${THREAD_POOL_SIZE}"
+          - "/vault-manager -dry-run=${DRY_RUN} -run-once=${RUN_ONCE} -kube-auth=${KUBE_AUTH} -thread-pool-size=${THREAD_POOL_SIZE}"
           env:
           - name: LOG_FILE_LOCATION
             value: ${LOG_FILE_LOCATION}
@@ -242,6 +242,9 @@ parameters:
   value: '/var/run/secrets/kubernetes.io/serviceaccount/token'
 - name: KUBE_AUTH_MOUNT
   value: ''
+- name: KUBE_AUTH
+  description: attempts to utilize kube auth on instances that support it
+  value: 'false'
 - name: DRY_RUN
   description: runs vault-manager in dry-run mode when true
   value: 'false'

--- a/helm/vault-manager/templates/template.yaml
+++ b/helm/vault-manager/templates/template.yaml
@@ -131,8 +131,10 @@ objects:
             value: ${LOG_FILE_LOCATION}
           - name: GRAPHQL_QUERY_FILE
             value: ${GRAPHQL_QUERY_FILE}
-          - name: DISABLE_IDENTITY
-            value: ${DISABLE_IDENTITY}
+          - name: KUBE_SA_TOKEN_PATH
+            value: ${KUBE_SA_TOKEN_PATH}
+          - name: KUBE_AUTH_MOUNT
+            value: ${KUBE_AUTH_MOUNT}
           - name: RECONCILE_SLEEP_TIME
             value: ${RECONCILE_SLEEP_TIME}
           - name: METRICS_SERVER_PORT
@@ -236,6 +238,10 @@ parameters:
   value: '3'
 - name: RECONCILE_SLEEP_TIME
   value: '15m'
+- name: KUBE_SA_TOKEN_PATH
+  value: '/var/run/secrets/kubernetes.io/serviceaccount/token'
+- name: KUBE_AUTH_MOUNT
+  value: ''
 - name: DRY_RUN
   description: runs vault-manager in dry-run mode when true
   value: 'false'
@@ -259,9 +265,6 @@ parameters:
   value: '/query.graphql'
 - name: VAULT_ADDR
   description: vault endpoint URL
-  value: ''
-- name: DISABLE_IDENTITY
-  description: disables entity and group toplevels when set
   value: ''
 - name: BUSYBOX_IMAGE
   value: quay.io/app-sre/ubi8-ubi-minimal

--- a/openshift/vault-manager-fedramp.template.yaml
+++ b/openshift/vault-manager-fedramp.template.yaml
@@ -101,7 +101,7 @@ objects:
           command: ["/bin/sh"]
           args: 
           - "-c"
-          - "/vault-manager -dry-run=${DRY_RUN} -run-once=${RUN_ONCE} -thread-pool-size=${THREAD_POOL_SIZE}"
+          - "/vault-manager -dry-run=${DRY_RUN} -run-once=${RUN_ONCE} -kube-auth=${KUBE_AUTH} -thread-pool-size=${THREAD_POOL_SIZE}"
           env:
           - name: LOG_FILE_LOCATION
             value: ${LOG_FILE_LOCATION}
@@ -218,6 +218,9 @@ parameters:
   value: '/var/run/secrets/kubernetes.io/serviceaccount/token'
 - name: KUBE_AUTH_MOUNT
   value: ''
+- name: KUBE_AUTH
+  description: attempts to utilize kube auth on instances that support it
+  value: 'false'
 - name: DRY_RUN
   description: runs vault-manager in dry-run mode when true
   value: 'false'

--- a/openshift/vault-manager-fedramp.template.yaml
+++ b/openshift/vault-manager-fedramp.template.yaml
@@ -217,7 +217,7 @@ parameters:
 - name: RECONCILE_SLEEP_TIME
   value: '15m'
 - name: KUBE_SA_TOKEN_PATH
-  value: ''
+  value: '/var/run/secrets/kubernetes.io/serviceaccount/token'
 - name: KUBE_AUTH_MOUNT
   value: ''
 - name: DRY_RUN

--- a/openshift/vault-manager-fedramp.template.yaml
+++ b/openshift/vault-manager-fedramp.template.yaml
@@ -244,9 +244,6 @@ parameters:
 - name: VAULT_ADDR
   description: vault endpoint URL
   value: ''
-- name: DISABLE_IDENTITY
-  description: disables entity and group toplevels when set
-  value: ''
 - name: BUSYBOX_IMAGE
   value: quay.io/app-sre/ubi8-ubi-minimal
 - name: BUSYBOX_IMAGE_TAG

--- a/openshift/vault-manager-fedramp.template.yaml
+++ b/openshift/vault-manager-fedramp.template.yaml
@@ -107,14 +107,12 @@ objects:
             value: ${LOG_FILE_LOCATION}
           - name: GRAPHQL_QUERY_FILE
             value: ${GRAPHQL_QUERY_FILE}
-          - name: DISABLE_IDENTITY
-            value: ${DISABLE_IDENTITY}
-          - name: RECONCILE_SLEEP_TIME
-            value: ${RECONCILE_SLEEP_TIME}
           - name: KUBE_SA_TOKEN_PATH
             value: ${KUBE_SA_TOKEN_PATH}
           - name: KUBE_AUTH_MOUNT
             value: ${KUBE_AUTH_MOUNT}
+          - name: RECONCILE_SLEEP_TIME
+            value: ${RECONCILE_SLEEP_TIME}
           - name: METRICS_SERVER_PORT
             value: ${METRICS_SERVER_PORT}
           - name: GRAPHQL_SERVER

--- a/openshift/vault-manager-fedramp.template.yaml
+++ b/openshift/vault-manager-fedramp.template.yaml
@@ -113,6 +113,8 @@ objects:
             value: ${RECONCILE_SLEEP_TIME}
           - name: KUBE_SA_TOKEN_PATH
             value: ${KUBE_SA_TOKEN_PATH}
+          - name: KUBE_AUTH_MOUNT
+            value: ${KUBE_AUTH_MOUNT}
           - name: METRICS_SERVER_PORT
             value: ${METRICS_SERVER_PORT}
           - name: GRAPHQL_SERVER
@@ -215,6 +217,8 @@ parameters:
 - name: RECONCILE_SLEEP_TIME
   value: '15m'
 - name: KUBE_SA_TOKEN_PATH
+  value: ''
+- name: KUBE_AUTH_MOUNT
   value: ''
 - name: DRY_RUN
   description: runs vault-manager in dry-run mode when true

--- a/openshift/vault-manager.template.yaml
+++ b/openshift/vault-manager.template.yaml
@@ -248,9 +248,6 @@ parameters:
 - name: VAULT_ADDR
   description: vault endpoint URL
   value: ''
-- name: DISABLE_IDENTITY
-  description: disables entity and group toplevels when set
-  value: ''
 - name: BUSYBOX_IMAGE
   value: quay.io/app-sre/ubi8-ubi-minimal
 - name: BUSYBOX_IMAGE_TAG

--- a/openshift/vault-manager.template.yaml
+++ b/openshift/vault-manager.template.yaml
@@ -221,7 +221,7 @@ parameters:
 - name: RECONCILE_SLEEP_TIME
   value: '15m'
 - name: KUBE_SA_TOKEN_PATH
-  value: ''
+  value: '/var/run/secrets/kubernetes.io/serviceaccount/token'
 - name: KUBE_AUTH_MOUNT
   value: ''
 - name: DRY_RUN

--- a/openshift/vault-manager.template.yaml
+++ b/openshift/vault-manager.template.yaml
@@ -117,6 +117,8 @@ objects:
             value: ${RECONCILE_SLEEP_TIME}
           - name: KUBE_SA_TOKEN_PATH
             value: ${KUBE_SA_TOKEN_PATH}
+          - name: KUBE_AUTH_MOUNT
+            value: ${KUBE_AUTH_MOUNT}
           - name: METRICS_SERVER_PORT
             value: ${METRICS_SERVER_PORT}
           - name: GRAPHQL_SERVER
@@ -219,6 +221,8 @@ parameters:
 - name: RECONCILE_SLEEP_TIME
   value: '15m'
 - name: KUBE_SA_TOKEN_PATH
+  value: ''
+- name: KUBE_AUTH_MOUNT
   value: ''
 - name: DRY_RUN
   description: runs vault-manager in dry-run mode when true

--- a/openshift/vault-manager.template.yaml
+++ b/openshift/vault-manager.template.yaml
@@ -111,14 +111,12 @@ objects:
             value: ${LOG_FILE_LOCATION}
           - name: GRAPHQL_QUERY_FILE
             value: ${GRAPHQL_QUERY_FILE}
-          - name: DISABLE_IDENTITY
-            value: ${DISABLE_IDENTITY}
-          - name: RECONCILE_SLEEP_TIME
-            value: ${RECONCILE_SLEEP_TIME}
           - name: KUBE_SA_TOKEN_PATH
             value: ${KUBE_SA_TOKEN_PATH}
           - name: KUBE_AUTH_MOUNT
             value: ${KUBE_AUTH_MOUNT}
+          - name: RECONCILE_SLEEP_TIME
+            value: ${RECONCILE_SLEEP_TIME}
           - name: METRICS_SERVER_PORT
             value: ${METRICS_SERVER_PORT}
           - name: GRAPHQL_SERVER

--- a/openshift/vault-manager.template.yaml
+++ b/openshift/vault-manager.template.yaml
@@ -105,7 +105,7 @@ objects:
           command: ["/bin/sh"]
           args: 
           - "-c"
-          - "/vault-manager -dry-run=${DRY_RUN} -run-once=${RUN_ONCE} -thread-pool-size=${THREAD_POOL_SIZE}"
+          - "/vault-manager -dry-run=${DRY_RUN} -run-once=${RUN_ONCE} -kube-auth=${KUBE_AUTH} -thread-pool-size=${THREAD_POOL_SIZE}"
           env:
           - name: LOG_FILE_LOCATION
             value: ${LOG_FILE_LOCATION}
@@ -222,6 +222,9 @@ parameters:
   value: '/var/run/secrets/kubernetes.io/serviceaccount/token'
 - name: KUBE_AUTH_MOUNT
   value: ''
+- name: KUBE_AUTH
+  description: attempts to utilize kube auth on instances that support it
+  value: 'false'
 - name: DRY_RUN
   description: runs vault-manager in dry-run mode when true
   value: 'false'

--- a/pkg/vault/instances.go
+++ b/pkg/vault/instances.go
@@ -212,9 +212,11 @@ func configureMaster(instanceCreds map[string]AuthBundle, kubeSATokenPath string
 }
 
 func configureKubeAuthClient(client *api.Client, bundle AuthBundle, kubeSATokenPath string) error {
+	mount := mustGetenv("KUBE_AUTH_MOUNT")
 	kubeAuth, err := kubernetes.NewKubernetesAuth(
 		bundle.KubeRoleName,
 		kubernetes.WithServiceAccountTokenPath(kubeSATokenPath),
+		kubernetes.WithMountPath(mount),
 	)
 	if err != nil {
 		return err

--- a/pkg/vault/instances.go
+++ b/pkg/vault/instances.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -69,19 +68,17 @@ var vaultClients map[string]*api.Client
 
 // Utilized to initialize vault instance clients for use by other toplevel integrations
 // returns list of instance addresses being included in reconcile
-func GetInstances(entriesBytes []byte, threadPoolSize int) []string {
+func GetInstances(entriesBytes []byte, kubeAuth bool, threadPoolSize int) []string {
 	var instances []Instance
 	if err := yaml.Unmarshal(entriesBytes, &instances); err != nil {
 		log.WithError(err).Fatal("[Vault Instance] failed to decode instance configuration")
 	}
 
-	// KUBE_SA_TOKEN_PATH is path on pod to kubernetes service account token
-	kubeSATokenPath, _ := os.LookupEnv("KUBE_SA_TOKEN_PATH")
-	instanceCreds, err := processInstances(instances, kubeSATokenPath)
+	instanceCreds, err := processInstances(instances, kubeAuth)
 	if err != nil {
 		log.WithError(err).Fatal("[Vault Instance] failed to retrieve access credentials")
 	}
-	initClients(instanceCreds, kubeSATokenPath, threadPoolSize)
+	initClients(instanceCreds, threadPoolSize)
 
 	// return list of addresses that clients were initialized for
 	addresses := []string{}
@@ -92,12 +89,12 @@ func GetInstances(entriesBytes []byte, threadPoolSize int) []string {
 }
 
 // generates map of instance addresses to access credentials stored in master vault
-func processInstances(instances []Instance, kubeSATokenPath string) (map[string]AuthBundle, error) {
+func processInstances(instances []Instance, kubeAuth bool) (map[string]AuthBundle, error) {
 	instanceCreds := make(map[string]AuthBundle)
 	for _, i := range instances {
 		bundle := AuthBundle{}
 		// conditions should only be met within cluster deployments
-		if len(kubeSATokenPath) > 0 && len(i.Auth.KubeRoleName) > 0 {
+		if kubeAuth && len(i.Auth.KubeRoleName) > 0 {
 			bundle.KubeRoleName = i.Auth.KubeRoleName
 		} else {
 			bundle.SecretEngine = i.Auth.SecretEngine
@@ -149,9 +146,9 @@ func processInstances(instances []Instance, kubeSATokenPath string) (map[string]
 
 // Creates global map of all vault clients defined in a-i
 // This allows reconciliation of multiple vault instances
-func initClients(instanceCreds map[string]AuthBundle, kubeSATokenPath string, threadPoolSize int) {
+func initClients(instanceCreds map[string]AuthBundle, threadPoolSize int) {
 	vaultClients = make(map[string]*api.Client) // THIS IS THE GLOBAL
-	masterAddress := configureMaster(instanceCreds, kubeSATokenPath)
+	masterAddress := configureMaster(instanceCreds)
 	bwg := utils.NewBoundedWaitGroup(threadPoolSize)
 	var mutex = &sync.Mutex{}
 	// read access credentials for other vault instances and configure clients
@@ -159,7 +156,7 @@ func initClients(instanceCreds map[string]AuthBundle, kubeSATokenPath string, th
 		// client already configured separately for master
 		if addr != masterAddress {
 			bwg.Add(1)
-			go createClient(addr, masterAddress, kubeSATokenPath, bundle, &bwg, mutex)
+			go createClient(addr, masterAddress, bundle, &bwg, mutex)
 		}
 	}
 	bwg.Wait()
@@ -168,7 +165,7 @@ func initClients(instanceCreds map[string]AuthBundle, kubeSATokenPath string, th
 // configureMaster initializes vault client for the master instance
 // This is the only client that can be configured using environment variables
 // env vars: VAULT_ADDR, VAULT_AUTHTYPE, VAULT_ROLE_ID, VAULT_SECRET_ID, VAULT_TOKEN
-func configureMaster(instanceCreds map[string]AuthBundle, kubeSATokenPath string) string {
+func configureMaster(instanceCreds map[string]AuthBundle) string {
 	masterVaultCFG := api.DefaultConfig()
 	masterVaultCFG.Address = mustGetenv("VAULT_ADDR")
 
@@ -180,7 +177,7 @@ func configureMaster(instanceCreds map[string]AuthBundle, kubeSATokenPath string
 	masterAuthBundle := instanceCreds[masterVaultCFG.Address]
 	// indicates kube auth should be utilized
 	if len(masterAuthBundle.KubeRoleName) > 0 {
-		err := configureKubeAuthClient(client, masterAuthBundle, kubeSATokenPath)
+		err := configureKubeAuthClient(client, masterAuthBundle)
 		if err != nil {
 			log.WithError(err).Fatal("[Vault Client] failed to configure master client using kube auth")
 		}
@@ -211,8 +208,9 @@ func configureMaster(instanceCreds map[string]AuthBundle, kubeSATokenPath string
 	return masterVaultCFG.Address
 }
 
-func configureKubeAuthClient(client *api.Client, bundle AuthBundle, kubeSATokenPath string) error {
+func configureKubeAuthClient(client *api.Client, bundle AuthBundle) error {
 	mount := mustGetenv("KUBE_AUTH_MOUNT")
+	kubeSATokenPath := mustGetenv("KUBE_SA_TOKEN_PATH")
 	kubeAuth, err := kubernetes.NewKubernetesAuth(
 		bundle.KubeRoleName,
 		kubernetes.WithServiceAccountTokenPath(kubeSATokenPath),
@@ -237,7 +235,6 @@ func configureKubeAuthClient(client *api.Client, bundle AuthBundle, kubeSATokenP
 // initializes one vault client
 func createClient(addr string,
 	masterAddress string,
-	kubeSATokenPath string,
 	bundle AuthBundle,
 	bwg *utils.BoundedWaitGroup,
 	mutex *sync.Mutex) {
@@ -256,7 +253,7 @@ func createClient(addr string,
 
 	// indicates kube auth should be utilized
 	if len(bundle.KubeRoleName) > 0 {
-		err := configureKubeAuthClient(client, bundle, kubeSATokenPath)
+		err := configureKubeAuthClient(client, bundle)
 		if err != nil {
 			log.WithError(err)
 			fmt.Println(fmt.Sprintf("[Vault Client] failed to login to %s with kube sa token", addr))


### PR DESCRIPTION
Changes:
* address bug when making call to init client using kube auth 
    - default requests are made to `auth/kubernetes/login`
    - our vault instances will enable multiple kube auths at unique paths `kubernetes-*`
* use flag for kube auth 
    - defaults to false
    - reduces clutter
* remove `DISABLE_IDENTITY` toggle
    - this is legacy feature no longer used