### PR TITLE
add service account token projected volume to template

### DIFF
--- a/helm/vault-manager/templates/template.yaml
+++ b/helm/vault-manager/templates/template.yaml
@@ -181,6 +181,8 @@ objects:
           volumeMounts:
           - name: logs
             mountPath: /fluentd/log
+          - name: vault-manager-token
+            mountPath: /var/run/secrets/kubernetes.io/serviceaccount
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -217,6 +219,12 @@ objects:
           emptyDir: {}
         - name: fluentd-config
           emptyDir: {}
+        - name: vault-manager-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
 parameters:
 - name: IMAGE
   value: quay.io/app-sre/vault-manager

--- a/openshift/vault-manager-fedramp.template.yaml
+++ b/openshift/vault-manager-fedramp.template.yaml
@@ -157,6 +157,8 @@ objects:
           volumeMounts:
           - name: logs
             mountPath: /fluentd/log
+          - name: vault-manager-token
+            mountPath: /var/run/secrets/kubernetes.io/serviceaccount
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -193,6 +195,12 @@ objects:
           emptyDir: {}
         - name: fluentd-config
           emptyDir: {}
+        - name: vault-manager-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
 parameters:
 - name: IMAGE
   value: quay.io/app-sre/vault-manager

--- a/openshift/vault-manager.template.yaml
+++ b/openshift/vault-manager.template.yaml
@@ -161,6 +161,8 @@ objects:
           volumeMounts:
           - name: logs
             mountPath: /fluentd/log
+          - name: vault-manager-token
+            mountPath: /var/run/secrets/kubernetes.io/serviceaccount
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -197,6 +199,12 @@ objects:
           emptyDir: {}
         - name: fluentd-config
           emptyDir: {}
+        - name: vault-manager-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
 parameters:
 - name: IMAGE
   value: quay.io/app-sre/vault-manager


### PR DESCRIPTION
projected volume of service account token is included in current version of openshift by default. Explicitly defining within template in order to override the default expiration of `3607` (equates to 1 year. see https://stackoverflow.com/questions/69375195/kubernetes-projected-service-account-token-expiry-time-issue)