### PR TITLE
APPSRE-7520: Retry function clean-up and refactor

### DIFF
--- a/pkg/vault/instances.go
+++ b/pkg/vault/instances.go
@@ -231,11 +231,7 @@ func configureKubeAuthClient(ctx context.Context, client *api.Client, bundle Aut
 		return err
 	}
 
-	if err := login(ctx, client, auth); err != nil {
-		return err
-	}
-
-	return nil
+	return login(ctx, client, auth)
 }
 
 func configureAppRoleAuthClient(ctx context.Context, client *api.Client, roleID, secretID string) error {
@@ -247,11 +243,7 @@ func configureAppRoleAuthClient(ctx context.Context, client *api.Client, roleID,
 		return err
 	}
 
-	if err := login(ctx, client, auth); err != nil {
-		return err
-	}
-
-	return nil
+	return login(ctx, client, auth)
 }
 
 func login(ctx context.Context, client *api.Client, auth api.AuthMethod) error {


### PR DESCRIPTION
Clean-up and refactor the Retry function so that:

- Use `errors.As()` instead of a type assertion to ensure that wrapped errors work correctly
- Refactor the `jitter()` function to use a more secure random number generator from the `crypto/rand` package
- Factor out some magic values into constants, such as the sleep step multiplier and jitter divider
- Drop surplus if-else around the `login()` function and return the error value directly

Signed-off-by: Krzysztof Wilczyński <kwilczynski@redhat.com>