### PR TITLE
Add mount as part of the unique key for roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.so
 *.dylib
 vault-manager
+!cmd/
 
 
 # Test binary, build with `go test -c`

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 *.so
 *.dylib
 vault-manager
-!cmd/
+!cmd/*
 
 
 # Test binary, build with `go test -c`

--- a/README.md
+++ b/README.md
@@ -47,6 +47,37 @@ From root of repo, run `source dev-env`
 
 You can now execute run vault-manager against the local vault instances. Note that after a non `-dry-run`, the resources will be added to the vault instances. To reset, simply rerun `local-dev.sh`
 
+Note: `--net=host` isn't supported for Mac([doc](https://docs.docker.com/network/drivers/host/)). So if you are developing from Mac, remove the flag from local-dev.sh and also remove key-cloak related `docker run` command.
+
+### Example launch.json for VS Code:
+```
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Launch Package",
+        "type": "go",
+        "request": "launch",
+        "mode": "auto",
+        "program": "${workspaceFolder}/cmd/vault-manager/main.go",
+        "args": ["--dry-run"],
+        "env": {
+          "VAULT_ADDR": "http://127.0.0.1:8200",
+          "VAULT_TOKEN": "root",
+          "VAULT_AUTHTYPE": "token",
+          "GRAPHQL_SERVER": "http://localhost:4000/graphql",
+          "GRAPHQL_QUERY_FILE": "/Users/olivia/SourceCode/app-sre/vault-manager/query.graphql"
+        }
+      }
+    ]
+  }
+```
+
+### Testing:
+
+This project use BATS for integration test, using mentioned primary and secondary vault instance. You can debug them by point environment variable `GRAPHQL_QUERY_FILE` to the .graphql under /fixtures.
+
+
 ## Gotchas
 
 ### Approle output_path

--- a/cmd/vault-manager/main.go
+++ b/cmd/vault-manager/main.go
@@ -145,7 +145,8 @@ func main() {
 				}
 				err = toplevel.Apply(config.Name, address, dataBytes, dryRun, threadPoolSize)
 				if err != nil {
-					if strings.Contains(err.Error(), "duplication") {
+					// Fail immediately if a duplication if found. Intend for pr_check.
+					if strings.Contains(err.Error(), "already exist") {
 						log.Fatalln(err)
 					}
 					fmt.Println(fmt.Sprintf("SKIPPING REMAINING RECONCILIATION FOR %s", address))

--- a/cmd/vault-manager/main.go
+++ b/cmd/vault-manager/main.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/app-sre/vault-manager/pkg/utils"
@@ -144,6 +145,9 @@ func main() {
 				}
 				err = toplevel.Apply(config.Name, address, dataBytes, dryRun, threadPoolSize)
 				if err != nil {
+					if strings.Contains(err.Error(), "duplication") {
+						log.Fatalln(err)
+					}
 					fmt.Println(fmt.Sprintf("SKIPPING REMAINING RECONCILIATION FOR %s", address))
 					status = 1
 					break

--- a/pkg/vault/reconcile.go
+++ b/pkg/vault/reconcile.go
@@ -202,9 +202,10 @@ func ValidateUniqueness(desiredItems []Item, toplevel string) error {
 	var uniqueNames = make(map[string]bool)
 	for _, item := range desiredItems {
 		itemName := item.Key()
-		_, exist := uniqueNames[itemName]
+		uniqueItemKey := strings.Join([]string{itemName, item.KeyForType()}, "")
+		_, exist := uniqueNames[uniqueItemKey]
 		if !exist {
-			uniqueNames[itemName] = true
+			uniqueNames[uniqueItemKey] = true
 		} else {
 			return fmt.Errorf("name %s already exist in %s", itemName, toplevel)
 		}

--- a/toplevel/audit/audit.go
+++ b/toplevel/audit/audit.go
@@ -76,9 +76,8 @@ func (c config) Apply(address string, entriesBytes []byte, dryRun bool, threadPo
 	}
 
 	desiredItems := asItems(instancesToDesiredAudits[address])
-	validateUniquenessError := vault.ValidateUniqueness(desiredItems, toplevelName)
-	if validateUniquenessError != nil {
-		log.Fatalln(validateUniquenessError)
+	if validateUniquenessError := vault.ValidateUniqueness(desiredItems, toplevelName); validateUniquenessError != nil {
+		return validateUniquenessError
 	}
 
 	// perform reconcile operations for specific instance

--- a/toplevel/auth/auth.go
+++ b/toplevel/auth/auth.go
@@ -119,9 +119,8 @@ func (c config) Apply(address string, entriesBytes []byte, dryRun bool, threadPo
 	updateOptionalKubeDefaults(instancesToDesired[address])
 
 	desiredItems := asItems(instancesToDesired[address])
-	validateUniquenessError := vault.ValidateUniqueness(desiredItems, toplevelName)
-	if validateUniquenessError != nil {
-		log.Fatalln(validateUniquenessError)
+	if validateUniquenessError := vault.ValidateUniqueness(desiredItems, toplevelName); validateUniquenessError != nil {
+		return validateUniquenessError
 	}
 
 	// Get the existing auth backends

--- a/toplevel/entity/entity.go
+++ b/toplevel/entity/entity.go
@@ -199,9 +199,8 @@ func (c config) Apply(address string, entriesBytes []byte, dryRun bool, threadPo
 	populateAliasType(desired)
 
 	desiredItems := asItems(desired)
-	validateUniquenessError := vault.ValidateUniqueness(desiredItems, toplevelName)
-	if validateUniquenessError != nil {
-		log.Fatalln(validateUniquenessError)
+	if validateUniquenessError := vault.ValidateUniqueness(desiredItems, toplevelName); validateUniquenessError != nil {
+		return validateUniquenessError
 	}
 
 	// Process data on existing entities/aliases

--- a/toplevel/group/group.go
+++ b/toplevel/group/group.go
@@ -143,9 +143,8 @@ func (c config) Apply(address string, entriesBytes []byte, dryRun bool, threadPo
 	sortSlices(existing)
 
 	desiredItems := asItems(desired)
-	validateUniquenessError := vault.ValidateUniqueness(desiredItems, toplevelName)
-	if validateUniquenessError != nil {
-		log.Fatalln(validateUniquenessError)
+	if validateUniquenessError := vault.ValidateUniqueness(desiredItems, toplevelName); validateUniquenessError != nil {
+		return validateUniquenessError
 	}
 
 	toBeWritten, toBeDeleted, toBeUpdated := vault.DiffItems(desiredItems, asItems(existing))

--- a/toplevel/policy/policy.go
+++ b/toplevel/policy/policy.go
@@ -65,6 +65,13 @@ func (c config) Apply(address string, entriesBytes []byte, dryRun bool, threadPo
 		instancesToDesiredPolicies[e.Instance.Address] = append(instancesToDesiredPolicies[e.Instance.Address], e)
 	}
 
+	desired := instancesToDesiredPolicies[address]
+	desiredItems := asItems((desired))
+
+	if validateUniquenessError := vault.ValidateUniqueness(desiredItems, toplevelName); validateUniquenessError != nil {
+		return validateUniquenessError
+	}
+
 	existingPolicyNames, err := vault.ListVaultPolicies(address)
 	if err != nil {
 		return err
@@ -105,14 +112,6 @@ func (c config) Apply(address string, entriesBytes []byte, dryRun bool, threadPo
 		if e != nil {
 			return e
 		}
-	}
-
-	desired := instancesToDesiredPolicies[address]
-	desiredItems := asItems((desired))
-
-	validateUniquenessError := vault.ValidateUniqueness(desiredItems, toplevelName)
-	if validateUniquenessError != nil {
-		log.Fatalln(validateUniquenessError)
 	}
 
 	// Diff the local configuration with the Vault instance.

--- a/toplevel/role/role.go
+++ b/toplevel/role/role.go
@@ -113,6 +113,11 @@ func (c config) Apply(address string, entriesBytes []byte, dryRun bool, threadPo
 		instancesToDesiredRoles[e.Instance.Address] = append(instancesToDesiredRoles[e.Instance.Address], e)
 	}
 
+	desiredRoles := instancesToDesiredRoles[address]
+	if validateUniquenessError := validateRoleUniqueness(desiredRoles, toplevelName); validateUniquenessError != nil {
+		return validateUniquenessError
+	}
+
 	// Get the existing auth backends
 	existingAuths, err := vault.ListAuthBackends(address)
 	if err != nil {
@@ -172,12 +177,6 @@ func (c config) Apply(address string, entriesBytes []byte, dryRun bool, threadPo
 			"instance": address,
 		}).Info("[Vault Role] failed to unmarshall oidc options of desired role")
 		return err
-	}
-
-	desiredRoles := instancesToDesiredRoles[address]
-	validateUniquenessError := validateRoleUniqueness(desiredRoles, toplevelName)
-	if validateUniquenessError != nil {
-		log.Fatalln(validateUniquenessError)
 	}
 
 	// Diff the desired configuration with the Vault instance.


### PR DESCRIPTION
### What:
* Add its own validate uniqueness function for roles so it can allow duplicated name for different mount
* Defer to caller in main to log fatal error and abort the process
* Allow /cmd/vault-manager to be git recognized

### Why
Roles can be of different mount but same name

### Validation:
Dry-run with roles that of different mount and duplicated names, the integration ran through;
Dry-run with roles that of the same mount and duplicated names, the integration failed;
