### PR TITLE
implement connection retries and extend login timeouts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.24.0
 toolchain go1.24.6
 
 require (
-	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/vault/api v1.10.0
 	github.com/hashicorp/vault/api/auth/approle v0.4.0
@@ -28,6 +27,7 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6 // indirect
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 toolchain go1.24.6
 
 require (
+	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/vault/api v1.10.0
 	github.com/hashicorp/vault/api/auth/approle v0.4.0
@@ -27,7 +28,6 @@ require (
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.6 // indirect
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect

--- a/pkg/vault/instances.go
+++ b/pkg/vault/instances.go
@@ -180,6 +180,8 @@ func configureMaster(instanceCreds map[string]AuthBundle) string {
 	masterVaultCFG := api.DefaultConfig()
 	masterVaultCFG.Address = mustGetenv("VAULT_ADDR")
 	masterVaultCFG.MaxRetries = 10
+	masterVaultCFG.MinRetryWait = 1 * time.Second
+	masterVaultCFG.MaxRetryWait = 30 * time.Second
 
 	client, err := api.NewClient(masterVaultCFG)
 	if err != nil {
@@ -280,6 +282,8 @@ func createClient(addr string, masterAddress string, bundle AuthBundle, bwg *uti
 	config := api.DefaultConfig()
 	config.Address = addr
 	config.MaxRetries = 10
+	config.MinRetryWait = 1 * time.Second
+	config.MaxRetryWait = 30 * time.Second
 	client, err := api.NewClient(config)
 	if err != nil {
 		log.WithError(err).Errorf("[Vault Client] failed to initialize Vault client for `%s`", addr)


### PR DESCRIPTION
Use [go-retryablehttp](https://github.com/hashicorp/go-retryablehttp) for Vault clients and increase login timeouts to 60s (from 5s). This prevents "context deadline exceeded" errors and crashloops during Vault leader elections and initialization windows.

Tracked in [APPSRE-13231](https://issues.redhat.com/browse/APPSRE-13231)
