### PR TITLE
feat(openshift): configure VAULT_AUTHTYPE via template parameter instead of secret

### DIFF
--- a/openshift/vault-manager.template.yaml
+++ b/openshift/vault-manager.template.yaml
@@ -144,10 +144,7 @@ objects:
           - name: VAULT_ADDR
             value: ${VAULT_ADDR}
           - name: VAULT_AUTHTYPE
-            valueFrom:
-              secretKeyRef:
-                key: auth_type
-                name: ${VAULT_SECRET_NAME}
+            value: ${VAULT_AUTHTYPE}
           - name: VAULT_ROLE_ID
             valueFrom:
               secretKeyRef:
@@ -260,6 +257,9 @@ parameters:
 - name: VAULT_ADDR
   description: vault endpoint URL
   value: ''
+- name: VAULT_AUTHTYPE
+  description: vault authentication type (e.g. approle, token)
+  value: 'approle'
 - name: INIT_IMAGE
   value: quay.io/app-sre/ubi8-ubi-minimal
 - name: INIT_IMAGE_TAG


### PR DESCRIPTION
## Summary
- Replace `VAULT_AUTHTYPE` secret key ref (`auth_type` from `vault-creds` secret) with a plain template parameter
- Add `VAULT_AUTHTYPE` parameter with default value `approle`

## Test plan
- [ ] Verify deployment renders correctly with `oc process` using the new parameter
- [ ] Confirm `VAULT_AUTHTYPE` can be overridden at deploy time